### PR TITLE
fix: --platform no longer allowed in snapcraft

### DIFF
--- a/snap-publish/action.yaml
+++ b/snap-publish/action.yaml
@@ -80,8 +80,7 @@ runs:
           # `core24` uses platforms syntax rather than `architectures`:
           # https://snapcraft.io/docs/architectures
           yq -i '.platforms |= {env(arch): {"build-on": env(arch)}}' "$yaml_path"
-          snapcraft_args+=("--platform $arch")
-        elif [[ "${{ steps.setup.outputs.new-remote-build }}" == "false" || "$SNAPCRAFT_REMOTE_BUILD_STRATEGY" == "force-fallback" ]]; then
+        elif [[ "$(yq -r '.architectures' "$yaml_path")" != null ]]; then
           # Restrict arch definition to one only in snapcraft.yaml due to:
           # https://bugs.launchpad.net/snapcraft/+bug/1885150
           yq -i '.architectures |= [{"build-on": env(arch)}]' "$yaml_path"


### PR DESCRIPTION
https://canonical-snapcraft.readthedocs-hosted.com/en/stable/reference/changelog/#id6