### PR TITLE
feat: policy check workflows

### DIFF
--- a/.github/workflows/corporate-policy.yaml
+++ b/.github/workflows/corporate-policy.yaml
@@ -1,0 +1,11 @@
+name: Canonical policy checks
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/team-policy.yaml
+++ b/.github/workflows/team-policy.yaml
@@ -1,0 +1,18 @@
+name: Team policy checks
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: conventional commits
+        uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          allowed-commit-types: "build,chore,ci,docs,feat,fix,perf,refactor,style,test"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ Some of these automations are provided as [Reusable workflows](https://docs.gith
 For these workflows, you can embed them in a workflow you run at the `job` level.
 Examples are provided below.
 
+## Policy checkers
+
+Two reusable workflows combine to check that a commit matches Canonical and team
+policies for PRs to our repositories. Right now, these checks are:
+
+- [CLA check](https://github.com/canonical/has-signed-canonical-cla)
+- [Commit message styles](https://github.com/canonical/starbase/blob/main/HACKING.rst#commits).
+
+### Usage
+
+```
+name: Policy
+on: [pull_request]
+
+jobs:
+  company:
+    uses: canonical/starflow/.github/workflows/corporate-policy.yaml@main
+  team:
+    uses: canonical/starflow/.github/workflows/team-policy.yaml@main
+
+```
+
 ## Python security scanner
 
 The Python security scanner workflow uses several tools (trivy, osv-scanner) to scan a


### PR DESCRIPTION
This adds two reusable workflows: a corporate policies one and a team policies one.

The corporate policies one currently contains only the CLA checker, and the team policies one currently contains only the Conventional Commits check. However, by placing these here, we can expand those groups as needed.

Example use: https://github.com/canonical/craft-parts/pull/861