### PR TITLE
fix(trivy): reduce frequency of trivy requests

### DIFF
--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -99,6 +99,7 @@ jobs:
         run: |
           for reqs in $(ls -1 requirements/*); do
             trivy filesystem --exit-code 1 ${{ inputs.trivy-extra-args }} "${reqs}"
+            sleep 1  # trivy rate-limits, will fail if requests are too close together
           done
       - name: Scan wheel files
         if: ${{ !cancelled() && hashFiles('*.whl') != '' }}


### PR DESCRIPTION
Fix failures like this:

```
2024-10-30T09:45:31Z	INFO	Need to update DB
2024-10-30T09:45:31Z	INFO	Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
2024-10-30T09:45:31Z	FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 268.995µs, allowed: 44000/minute
Error: Process completed with exit code 1.
```