### PR TITLE
feat(scan-python): more configurable uv

### DIFF
--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -9,6 +9,16 @@ on:
         description: |
           Packages to install with apt when building the wheel or scanning with trivy
           This can be useful if creating a virtual environment has extra build-deps.
+      uv-export:
+        type: boolean
+        default: true
+        description: |
+          Whether to export requirements files from uv. Defaults to true.
+      uv-sync-extra-args:
+        type: string
+        default: "--no-dev --all-extras"
+        description: |
+          Extra arguments to pass to uv when using sync to generate a virtual environment.
       requirements-find-args:
         required: false
         type: string
@@ -61,7 +71,7 @@ jobs:
         run: |
           python -m build --wheel --outdir ${{ runner.temp }}/python-artefacts
       - name: Create requirements files from uv
-        if: ${{ hashFiles('uv.lock') != '' }}
+        if: ${{ inputs.uv-export && hashFiles('uv.lock') != ''}}
         run: |
           uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements.txt
           uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt --all-extras --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements-all.txt
@@ -147,6 +157,12 @@ jobs:
             trivy filesystem --exit-code 1 ${{ inputs.trivy-extra-args }} "${venv}"
             deactivate
           done
+      - name: Scan uv workspace
+        if: ${{ hashFiles('source/uv.lock') != ''}}
+        run: |
+          cd source
+          uv sync ${{ uv-sync-extra-args }}
+          trivy filesystem --exit-code 1 ${{ inputs.trivy-extra-args }} .venv
   scan-osv:
     name: OSV-scanner
     needs: build-artefacts

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -26,6 +26,12 @@ on:
         description: |
           Additional arguments to use for find when finding requirements files. Can
           be used to find additional files or to exclude files.
+      uv-export-extra-args:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Additional arguments for uv export commands (for example to ignore certain extras).
       osv-extra-args:
         required: false
         type: string
@@ -73,8 +79,8 @@ jobs:
       - name: Create requirements files from uv
         if: ${{ inputs.uv-export && hashFiles('uv.lock') != ''}}
         run: |
-          uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements.txt
-          uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt --all-extras --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements-all.txt
+          uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt ${{ inputs.uv-export-extra-args }} --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements.txt
+          uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt ${{ inputs.uv-export-extra-args }} --all-extras --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements-all.txt
       - name: Upload artefacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -16,7 +16,7 @@ on:
           Whether to export requirements files from uv. Defaults to true.
       uv-sync-extra-args:
         type: string
-        default: "--no-dev --all-extras"
+        default: ""
         description: |
           Extra arguments to pass to uv when using sync to generate a virtual environment.
       requirements-find-args:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Python project for security issues. It does the following:
    b. `requirements-all.txt` with all available extras
 
 If there are any existing `requirements*.txt` files in your project, it will scan those
-below too.
+below too. Exporting a `uv.lock` file can be disabled by setting `uv-export: false`.
 
 With [Trivy](https://github.com/aquasecurity/trivy), it:
 
@@ -81,6 +81,8 @@ With [Trivy](https://github.com/aquasecurity/trivy), it:
 2. Scans the wheel file(s)
 3. Scans the project directory
 4. Installs each combination of (requirements, wheel) in a virtual environment and scans that environment.
+5. If a `uv.lock` file exists for the project, creates a virtual environment using `uv sync` and
+   scans that environment. `uv sync` can be configured with the `uv-sync-extra-args` input.
 
 With [OSV-scanner](https://google.github.io/osv-scanner/) it:
 


### PR DESCRIPTION
This allows disabling of uv.lock exporting (needed because uv cannot always export to requirements.txt) and adds a trivy scan using a uv sync created virtual environment.