### PR TITLE
fix!(renovate): move to a standard location

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,0 @@
-{
-    extends: ["github>canonical/starflow:renovate-base.json5"],
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,1 +1,3 @@
-../renovate-base.json5
+{
+    extends: ["github>canonical/starflow:renovate-base.json5"],
+}

--- a/.github/workflows/self-test-renovate.yaml
+++ b/.github/workflows/self-test-renovate.yaml
@@ -2,8 +2,8 @@ name: Check what the renovate run would do.
 on:
   pull_request:
     paths:
-      - ".github/**"
-      - "renovate-base.json5"
+      - ".github/workflows/self-test-renovate.yaml"
+      - "renovate.json5"
   push:
     branches:
       - work/renovate # For development
@@ -37,9 +37,10 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Check renovate config
-        run: renovate-config-validator renovate-base.json5
+        run: renovate-config-validator renovate.json5
       - name: Renovate dry-run
-        run: renovate --platform=local --dry-run=full
+        run: |
+          renovate --platform=local --dry-run=full
         env:
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_USE_BASE_BRANCH_CONFIG: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -191,6 +191,6 @@ configured to use this by adding the following to its `.github/renovate.json5` f
 
 ```json5
 {
-  extends: ["github:canonical/starflow:renovate-base.json5"],
+  extends: ["github>canonical/starflow"],
 }
 ```

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,6 @@
 {
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
+  // NOTE: This file acts as the renovate configuration for all Starcraft repositories.
   extends: ["config:recommended", ":semanticCommitTypeAll(build)", ":enablePreCommit"],
   labels: [
     "dependencies", // For convenient searching in GitHub


### PR DESCRIPTION
The renovate GitHub app doesn't like symlinks, which isn't something that running renovate locally catches. This changes the renovate config to simply extend the renovate base config we have.

This limits us because our per-repo renovate config can't be different from the base config for this repo, but trying to link renovate to inherit from a different config file in the same repository has just found a bunch of issues in renovate.

Fixes #25 