### PR TITLE
fix: only run CLA check on pull requests

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   cla:
+    if: github.event_name == 'pull_request'
     name: Authors signed Canonical CLA
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It doesn't make sense to run the CLA checker once we're already on `main` and it fails anyway.

This returns us back to the [standard method](https://github.com/canonical/has-signed-canonical-cla) which is to just run on PRs.