### PR TITLE
feat: install pyright snap

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Begin snap installs of common linters
         id: snap-install
         run: |
-          echo -n 'jobs="$(sudo snap install --no-wait --classic codespell pyright ruff shellcheck)"' >> $GITHUB_OUTPUT
+          echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck) $(sudo snap install --no-wait --classic pyright)"' >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up uv with caching

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Begin snap installs of common linters
         id: snap-install
         run: |
-          echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck)"' >> $GITHUB_OUTPUT
+          echo -n 'jobs="$(sudo snap install --no-wait codespell pyright ruff shellcheck)"' >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up uv with caching

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Begin snap installs of common linters
         id: snap-install
         run: |
-          echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck) $(sudo snap install --no-wait --classic pyright)"' >> $GITHUB_OUTPUT
+          echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck)" "$(sudo snap install --no-wait --classic pyright)"' >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up uv with caching

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -16,8 +16,7 @@ jobs:
       - name: Begin snap installs of common linters
         id: snap-install
         run: |
-          echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck)"' >> $GITHUB_OUTPUT
-          echo -n 'jobs="$(sudo snap install --no-wait --classic pyright)"' >> $GITHUB_OUTPUT
+          echo -n 'jobs="$(sudo snap install --no-wait --classic codespell pyright ruff shellcheck)"' >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up uv with caching

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -16,7 +16,8 @@ jobs:
       - name: Begin snap installs of common linters
         id: snap-install
         run: |
-          echo -n 'jobs="$(sudo snap install --no-wait codespell pyright ruff shellcheck)"' >> $GITHUB_OUTPUT
+          echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck)"' >> $GITHUB_OUTPUT
+          echo -n 'jobs="$(sudo snap install --no-wait --classic pyright)"' >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up uv with caching


### PR DESCRIPTION
Installs the pyright snap in Ci.

This should have shown up in https://github.com/canonical/charmcraft/pull/2052, but `uv sync` was not run so `pyright` is still in the lockfile.  Once `uv sync` removes it, the [workflow fails](https://github.com/canonical/charmcraft/actions/runs/12397682653/job/34608641569?pr=2054#step:6:27).