### PR TITLE
fix: Properly set python version for uv

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up uv with caching
         id: setup-uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
       - name: Set up linters

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -29,9 +29,10 @@ on:
       uv-export-extra-args:
         required: false
         type: string
-        default: ""
+        default: "--all-extras"
         description: |
-          Additional arguments for uv export commands (for example to ignore certain extras).
+          List of additional arguments for uv export commands (for example to ignore certain extras).
+          Use multiline string to provide several sets of arguments.
       osv-extra-args:
         required: false
         type: string
@@ -79,8 +80,12 @@ jobs:
       - name: Create requirements files from uv
         if: ${{ inputs.uv-export && hashFiles('uv.lock') != ''}}
         run: |
-          uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt ${{ inputs.uv-export-extra-args }} --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements.txt
-          uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt ${{ inputs.uv-export-extra-args }} --all-extras --output-file=${{ runner.temp }}/python-artefacts/requirements/uv-requirements-all.txt
+          IFS=$'\n'
+          for extras in $(echo "${{ inputs.uv-export-extra-args }}"); do
+            unset IFS
+            filename=uv-requirements.$(echo $extras | tr ' ' '_').txt
+            uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt $extras --output-file=${{ runner.temp }}/python-artefacts/requirements/$filename
+          done
       - name: Upload artefacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -16,4 +16,4 @@ jobs:
       fast-test-python-versions: '["3.14"]'
       slow-test-platforms: '["ubuntu-latest"]'
       slow-test-python-versions: '["3.14"]'
-      lowest-python-version: "3.0"
+      lowest-python-version: "3.8"

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -37,6 +37,7 @@ jobs:
   fast:
     name: Fast tests
     strategy:
+      fail-fast: false
       matrix:
         platform: ${{ fromJson(inputs.fast-test-platforms) }}
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -68,7 +68,7 @@ jobs:
           echo "cache-hash=$(echo '${{ toJSON(matrix.platform) }}' | sha1sum | cut -f1 -d' ')" >> $GITHUB_OUTPUT
       - name: Set up uv with caching
         id: setup-uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-suffix: ${{ steps.runner-info.outputs.cache-hash }}
@@ -135,10 +135,11 @@ jobs:
 
       - name: Set up uv with caching
         id: setup-uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-suffix: ${{ toJSON(matrix.platform) }}
+          python-version: ${{ matrix.python-version }}
       - name: Install tools
         run: |
           make setup-tests
@@ -158,7 +159,6 @@ jobs:
     if: ${{ inputs.lowest-python-version != '' }}
     runs-on: ${{ inputs.lowest-python-platform }}
     env:
-      UV_PYTHON: ${{ inputs.lowest-python-version }}
       UV_RESOLUTION: lowest
     steps:
       - uses: actions/checkout@v4
@@ -166,10 +166,11 @@ jobs:
           fetch-depth: 0
       - name: Set up uv with caching
         id: setup-uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-suffix: lowest-jammy
+          python-version: ${{ inputs.lowest-python-version }}
       - name: Install tools
         run: |
           make setup-tests

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
           enable-cache: true
           cache-suffix: ${{ steps.runner-info.outputs.cache-hash }}
+          ignore-nothing-to-cache: true
       - name: Set up tests
         shell: bash
         run: |
@@ -141,6 +142,7 @@ jobs:
           enable-cache: true
           cache-suffix: ${{ toJSON(matrix.platform) }}
           python-version: ${{ matrix.python-version }}
+          ignore-nothing-to-cache: true
       - name: Install tools
         run: |
           make setup-tests
@@ -172,6 +174,7 @@ jobs:
           enable-cache: true
           cache-suffix: lowest-jammy
           python-version: ${{ inputs.lowest-python-version }}
+          ignore-nothing-to-cache: true
       - name: Install tools
         run: |
           make setup-tests


### PR DESCRIPTION
- Update astral-sh/setup-uv to v5, supporting declaring the python version wanted in the venv.
- Use the python-version to create a venv with the requested python version
- Enable re-running a failed job if another one failed by disabling fail-fast. 