### PR TITLE
feat(test-python): allow arrays for lowest python platform

### DIFF
--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -17,3 +17,4 @@ jobs:
       slow-test-platforms: '["ubuntu-latest"]'
       slow-test-python-versions: '["3.14"]'
       lowest-python-version: "3.8"
+      lowest-python-platform: '["jammy", "arm64"]'

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -160,7 +160,10 @@ jobs:
   lowest:
     name: Minimum dependencies (all tests)
     if: ${{ inputs.lowest-python-version != '' }}
-    runs-on: ${{ inputs.lowest-python-platform }}
+    # Allows either a string containing the platform or a JSON list of tags.
+    # This is done for backwards compatibility with a string lowest-python version while
+    # still allowing a list of tags if needed.
+    runs-on: ${{ startsWith(inputs.lowest-python-platform, '[') && fromJson(inputs.lowest-python-platform) || inputs.lowest-python-platform }}
     env:
       UV_RESOLUTION: lowest
     steps:


### PR DESCRIPTION
This allows the lowest-dependencies Python platform to contain a list of tags.

It keeps the same default of `ubuntu-20.04`, which [succeeds here](https://github.com/canonical/starflow/actions/runs/13120125732/job/36603888180?pr=43), but also allows a list of tags like `["jammy", "arm64"]`, which [succeeds here](https://github.com/canonical/starflow/actions/runs/13120125732/job/36603890404?pr=43).

The motivation is to allow craft-application to test on the lowest versions: https://github.com/canonical/craft-application/actions/runs/13083693096/job/36601983812?pr=622