### PR TITLE
ci: update has-signed-canonical-cla to v2

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@v2
   commits:
     name: Conventional Commits
     runs-on: ubuntu-latest


### PR DESCRIPTION
[v2.0.0](https://github.com/canonical/has-signed-canonical-cla/releases/tag/2.0.0) makes a number of changes, but importantly for me it fixes an [issue](https://github.com/canonical/has-signed-canonical-cla/issues/63) that was occurring in craft-providers.