### PR TITLE
fix: support build and publish of 'all'

### DIFF
--- a/snap-publish/action.yaml
+++ b/snap-publish/action.yaml
@@ -110,7 +110,8 @@ runs:
         echo '## Snapcraft Remote Build Logs'  >> "$GITHUB_STEP_SUMMARY"
         echo '<details>'  >> "$GITHUB_STEP_SUMMARY"
         echo \`\`\`   >> "$GITHUB_STEP_SUMMARY"
-        cat snapcraft-"${name}"*"${arch}"*.txt   >> "$GITHUB_STEP_SUMMARY"
+        cat snapcraft-"${name}"*"${arch}"*.txt   >> "$GITHUB_STEP_SUMMARY" || cat snapcraft-"${name}"*.txt   >> "$GITHUB_STEP_SUMMARY"
+
         echo \`\`\`   >> "$GITHUB_STEP_SUMMARY"
         echo '</details>'  >> "$GITHUB_STEP_SUMMARY"
 

--- a/snap-publish/action.yaml
+++ b/snap-publish/action.yaml
@@ -76,10 +76,12 @@ runs:
 
         echo "::group::set platform"
         # shellcheck disable=SC2193
-        if [[ "$(yq -r '.base' "$yaml_path")" == "core24" ]] && [ "${arch}" != "all" ]; then
+        if [[ "$(yq -r '.base' "$yaml_path")" == "core24" ]]; then
           # `core24` uses platforms syntax rather than `architectures`:
           # https://snapcraft.io/docs/architectures
-          yq -i '.platforms |= {env(arch): {"build-on": env(arch)}}' "$yaml_path"
+          if [[ "${arch}" != "all" ]]; then
+            yq -i '.platforms |= {env(arch): {"build-on": env(arch)}}' "$yaml_path"
+          fi
         elif [[ "$(yq -r '.architectures' "$yaml_path")" != null ]]; then
           # Restrict arch definition to one only in snapcraft.yaml due to:
           # https://bugs.launchpad.net/snapcraft/+bug/1885150

--- a/snap-publish/action.yaml
+++ b/snap-publish/action.yaml
@@ -76,7 +76,7 @@ runs:
 
         echo "::group::set platform"
         # shellcheck disable=SC2193
-        if [[ "$(yq -r '.base' "$yaml_path")" == "core24" ]]; then
+        if [[ "$(yq -r '.base' "$yaml_path")" == "core24" ]] && [ "${arch}" != "all" ]; then
           # `core24` uses platforms syntax rather than `architectures`:
           # https://snapcraft.io/docs/architectures
           yq -i '.platforms |= {env(arch): {"build-on": env(arch)}}' "$yaml_path"


### PR DESCRIPTION
Do not override `platforms` if "all" is defined.
Fallback to reading any logfile if "{arch}"-based one cannot be found - for "all", build log has a suffix of the architecture it was build on, not "all"