### PR TITLE
fix(test-python): switch the default min python platform to 22.04

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -26,7 +26,7 @@ on:
         type: string
         description: |
           The platform to run the lowest python version tests on.
-        default: "ubuntu-20.04"
+        default: "ubuntu-22.04"
       lowest-python-version:
         type: string
         description: |


### PR DESCRIPTION
This is in response to Focal being turned off on Github Runners: https://github.com/actions/runner-images/issues/11101