### PR TITLE
ci: update apt before installing build deps

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -74,6 +74,10 @@ jobs:
           enable-cache: true
           cache-suffix: ${{ steps.runner-info.outputs.cache-hash }}
           ignore-nothing-to-cache: true
+      - name: Update Apt
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
       - name: Set up tests
         shell: bash
         run: |
@@ -143,6 +147,10 @@ jobs:
           cache-suffix: ${{ toJSON(matrix.platform) }}
           python-version: ${{ matrix.python-version }}
           ignore-nothing-to-cache: true
+      - name: Update Apt
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
       - name: Install tools
         run: |
           make setup-tests
@@ -178,6 +186,10 @@ jobs:
           cache-suffix: lowest-jammy
           python-version: ${{ inputs.lowest-python-version }}
           ignore-nothing-to-cache: true
+      - name: Update Apt
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
       - name: Install tools
         run: |
           make setup-tests


### PR DESCRIPTION
The runners are not guaranteed to have a valid apt cache, so call `apt update` before `make setup-tests` (which runs `install-build-deps`).