### PR TITLE
ci(renovate): ignore certain packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,8 +13,8 @@
     {
       // Exclude certain Python packages that will require manual changes.
       matchPackageNames: [
-        "python-apt",  # Version is tightly coupled to the base OS.
-        "pygit2",      # Version is coupled to libgit2.
+        "python-apt",  // Version is tightly coupled to the base OS.
+        "pygit2",      // Version is coupled to libgit2.
       ],
       enabled: false,
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,8 +13,8 @@
     {
       // Exclude certain Python packages that will require manual changes.
       matchPackageNames: [
-        "python-apt",  // Version is tightly coupled to the base OS.
-        "pygit2",      // Version is coupled to libgit2.
+        "python-apt", // Version is tightly coupled to the base OS.
+        "pygit2", // Version is coupled to libgit2.
       ],
       enabled: false,
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,14 @@
   },
   packageRules: [
     {
+      // Exclude certain Python packages that will require manual changes.
+      matchPackageNames: [
+        "python-apt",  # Version is tightly coupled to the base OS.
+        "pygit2",      # Version is coupled to libgit2.
+      ],
+      enabled: false,
+    },
+    {
       // Internal package minor patch updates get top priority, with auto-merging
       groupName: "internal package minor releases",
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
This configures Renovate to ignore certain packages.

The two ignored currently are:

- python-apt (version is tightly coupled to the base OS) https://github.com/canonical/craft-sd/pull/27
- pygit2 (version is tightly coupled to libgit2, for which we use the base)