### PR TITLE
fix: use self hosted runner for tics

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   TICS:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, noble, amd64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
At some point in time it looks like Charmcraft started to use lxd in tests, the self hosted runners are mostly preconfigured for this to work out of the box.

---
Working action https://github.com/canonical/charmcraft/actions/runs/14606116055/job/40976094707?pr=2258

Failing action https://github.com/canonical/charmcraft/actions/runs/14605447468/job/40973362344