### PR TITLE
feat(renovate): add starcraft-reviewers as default reviewers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -156,4 +156,5 @@
   minimumReleaseAge: "2 days",
   automergeStrategy: "squash", // Squash & rebase when auto-merging.
   semanticCommitType: "build", // use `build` as commit header type (i.e. `build(deps): <description>`)
+  reviewers: ["team:starcraft-reviewers"], // Always add general reviewers
 }


### PR DESCRIPTION
This adds the starcraft-reviewers team to all renovate PRs automatically.