### PR TITLE
feat(test-python): allow filtering by markers

### DIFF
--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -19,3 +19,4 @@ jobs:
       lowest-python-version: "3.8"
       lowest-python-platform: '["jammy", "arm64"]'
       use-lxd: true
+      pytest-markers: smoketest and not steamtest

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -37,6 +37,10 @@ on:
         description: |
           Whether to set up LXD on Linux runners.
         default: false
+      pytest-markers:
+        type: string
+        description: |
+          A pytest marker filter to add when running the tests.
 
 jobs:
   fast:
@@ -95,12 +99,14 @@ jobs:
           done
       - name: Run tests
         shell: bash
+        env:
+          MARKERS: ${{ inputs.pytest-markers }}
         run: |
           exit_code=0
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do
             echo "::group::Python ${python_version}"
             python_dirname=$(echo ${{ runner.temp }} | tr '\\' /)/venv_$(echo $python_version | tr . _)
-            if ! make test-coverage UV_PROJECT_ENVIRONMENT="${python_dirname}" PYTEST_ADDOPTS="-m 'not slow'" UV_PYTHON="${python_version}"
+            if ! make test-coverage UV_PROJECT_ENVIRONMENT="${python_dirname}" PYTEST_ADDOPTS="-m 'not slow ${MARKERS:+and ($MARKERS)}'" UV_PYTHON="${python_version}"
             then
               exit_code=1
               echo "::error title=TESTS FAILED::Tests failed with Python ${python_version}"
@@ -123,8 +129,6 @@ jobs:
         platform: ${{ fromJson(inputs.slow-test-platforms) }}
         python-version: ${{ fromJson(inputs.slow-test-python-versions) }}
     runs-on: ${{ matrix.platform }}
-    env:
-      PYTEST_ADDOPTS: --no-header -v -rN -m 'slow'
     steps:
       - name: Setup LXD
         if: ${{ runner.os == 'Linux' && inputs.use-lxd }}
@@ -166,8 +170,10 @@ jobs:
         run: |
           make setup-tests
       - name: Run tests
+        env:
+          MARKERS: ${{ inputs.pytest-markers }}
         run: |
-          make test-coverage
+          make test-coverage PYTEST_ADDOPTS="--no-header -v -rN -m 'slow ${MARKERS:+and ($MARKERS)}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v4
         with:
@@ -208,8 +214,10 @@ jobs:
         run: |
           make setup-tests
       - name: Run tests
+        env:
+          MARKERS: ${{ inputs.pytest-markers }}
         run: |
-          make test-coverage
+          make test-coverage PYTEST_ADDOPTS="-m '${MARKERS}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,6 @@ setup-tests:
 test-coverage:
 	$(info Simulating coverage creation)
 	$(info "Running tests with extra pytest options: ${PYTEST_ADDOPTS}")
+	$(info "Markers set: $(MARKERS)")
 	$(info "Using Python ${UV_PYTHON}")
 	@touch coverage.xml

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ on:
 jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: '["ubuntu-22.04", "windows-latest", "macos-latest"]'
+      fast-test-python-versions: '["3.14"]'
+      slow-test-platforms: '["ubuntu-latest"]'
+      slow-test-python-versions: '["3.14"]'
+      lowest-python-version: "3.8"
+      lowest-python-platform: '["jammy", "arm64"]'
+      use-lxd: true # If we should install lxd on the runner.
+      pytest-markers: smoketest and not steamtest # Extra pytest marks to set, for example to break up large test sets
 ```
 
 # Other Configuration


### PR DESCRIPTION
This allows filtering test runs by markers, allowing the splitting of tests into multiple jobs.

craft-providers will use this so we can separate the various categories of slow tests (lxd, multipass, other)

View this in use at: https://github.com/canonical/craft-providers/actions/runs/15478603156/job/43579839334?pr=748