### PR TITLE
chore: fix renovate branching

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,7 @@
   pip_requirements: {
     fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$"],
   },
+  branchPrefix: "work/renovate/",
   packageRules: [
     {
       // Exclude certain Python packages that will require manual changes.


### PR DESCRIPTION
Renovate attempts to make force pushes to its own branches, but we have rather restrictive branch rules set up for dev branches. To loosen the restrictions, Renovate can make its branches under `work/` instead.