### PR TITLE
ci: drop redundant cla check

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -9,13 +9,6 @@ on:
       - main
 
 jobs:
-  cla:
-    if: github.event_name == 'pull_request'
-    name: Authors signed Canonical CLA
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v2
   commits:
     name: Conventional Commits
     runs-on: ubuntu-latest


### PR DESCRIPTION
The [cla check](https://github.com/canonical/cla-workflow-hosting/blob/93f36d8a49231d6132c203336148ce91335ef7b0/.github/workflows/cla.yml) is now an org-wide workflow, so we don't need to run it twice.