### PR TITLE
fix(lint-python): fetch history

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -19,6 +19,8 @@ jobs:
           echo -n 'jobs="$(sudo snap install --no-wait codespell ruff shellcheck)"' >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Sphinx's linting uses the git history when getting timestamps.
       - name: Set up uv with caching
         id: setup-uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
This is needed because canonical-sphinx uses [the git history](https://github.com/mgeier/sphinx-last-updated-by-git) to generate timestamps.

Example failure: https://github.com/canonical/starbase/actions/runs/16953811410/job/48051792476?pr=426#step:6:91