### PR TITLE
feat(test-python): Add Python 3.14 to the defaults

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -9,7 +9,7 @@ on:
           The platforms to run fast tests on, as a JSON array.
       fast-test-python-versions:
         type: string
-        default: '["3.10", "3.11", "3.12", "3.13"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
         description: |
           The python versions to run fast tests on, as a JSON array.
       slow-test-platforms:
@@ -19,7 +19,7 @@ on:
           The platforms to run slow tests on, as a JSON array.
       slow-test-python-versions:
         type: string
-        default: '["3.10"]'
+        default: '["3.10", "3.14"]'
         description: |
           The python versions to run slow tests on, as a JSON array.
       lowest-python-platform:


### PR DESCRIPTION
This defaults to testing on Python 3.14 so we can find incompatibilities before the push for core26.