### PR TITLE
style(ci): make renovate label consistent with other starcraft labels

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   // NOTE: This file acts as the renovate configuration for all Starcraft repositories.
   extends: ["config:recommended", ":semanticCommitTypeAll(build)", ":enablePreCommit"],
-  labels: ["dependencies"],
+  labels: ["Dependencies"],
   baseBranchPatterns: ["$default", "/^hotfix\\/.*/"],
   pip_requirements: {
     managerFilePatterns: ["/^tox.ini$/", "/(^|/)requirements([\\w-]*)\\.txt$/"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   // NOTE: This file acts as the renovate configuration for all Starcraft repositories.
   extends: ["config:recommended", ":semanticCommitTypeAll(build)", ":enablePreCommit"],
-  labels: ["Dependencies"],
+  labels: ["PR: Dependencies"],
   baseBranchPatterns: ["$default", "/^hotfix\\/.*/"],
   pip_requirements: {
     managerFilePatterns: ["/^tox.ini$/", "/(^|/)requirements([\\w-]*)\\.txt$/"],


### PR DESCRIPTION
Currently Renovate adds a label called `dependencies` to any PR it opens, but all of our other labels capitalize each word.

Once this is merged, a PR will be put up in the repo automation repository to codify this label and stop the bot from deleting it from all of the Renovate PRs.