### PR TITLE
feat(test-python): setup in parallel

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do
             python_dirname=$(echo ${{ runner.temp }} | tr '\\' /)/venv_$(echo $python_version | tr . _)
-            make setup-tests UV_PROJECT_ENVIRONMENT="${python_dirname}" UV_PYTHON="${python_version}"
+            make -j setup-tests UV_PROJECT_ENVIRONMENT="${python_dirname}" UV_PYTHON="${python_version}"
           done
       - name: Run tests
         shell: bash
@@ -99,7 +99,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tools
         run: |
-          make setup-tests
+          make -j setup-tests
       - name: Run tests
         env:
           MARKERS: ${{ inputs.pytest-markers }}
@@ -129,7 +129,7 @@ jobs:
           python-version: ${{ inputs.lowest-python-version }}
       - name: Install tools
         run: |
-          make setup-tests
+          make -j setup-tests
       - name: Run tests
         env:
           MARKERS: ${{ inputs.pytest-markers }}


### PR DESCRIPTION
Changes the configuration jobs so `make setup-tests` runs with unlimited jobs rather than a single job.