### PR TITLE
feat(lint-python): install linters in parallel

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -31,6 +31,6 @@ jobs:
           for job in ${{ steps.snap-install.outputs.jobs }}; do
             sudo snap watch $job
           done
-          make setup-lint
+          make -j setup-lint
       - name: Run linters
         run: make -k lint


### PR DESCRIPTION
Changes the lint-python job to install linters in parallel.