### PR TITLE
feat(test-python): allow extra environment variables during setup

### DIFF
--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -20,3 +20,4 @@ jobs:
       lowest-python-platform: '["jammy", "arm64"]'
       use-lxd: true
       pytest-markers: smoketest and not steamtest
+      setup-vars: SETUP_EXTRA=1

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -41,6 +41,10 @@ on:
         type: string
         description: |
           A pytest marker filter to add when running the tests.
+      setup-vars:
+        type: string
+        description: |
+          Additional environment variables to use during setup.
 
 jobs:
   fast:
@@ -58,7 +62,7 @@ jobs:
         run: |
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do
             python_dirname=$(echo ${{ runner.temp }} | tr '\\' /)/venv_$(echo $python_version | tr . _)
-            make setup-tests UV_PROJECT_ENVIRONMENT="${python_dirname}" UV_PYTHON="${python_version}"
+            make setup-tests UV_PROJECT_ENVIRONMENT="${python_dirname}" UV_PYTHON="${python_version}" ${{ inputs.setup-vars }}
           done
       - name: Run tests
         shell: bash
@@ -99,7 +103,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tools
         run: |
-          make setup-tests
+          make setup-tests ${{ inputs.setup-vars }}
       - name: Run tests
         env:
           MARKERS: ${{ inputs.pytest-markers }}
@@ -129,7 +133,7 @@ jobs:
           python-version: ${{ inputs.lowest-python-version }}
       - name: Install tools
         run: |
-          make setup-tests
+          make setup-tests ${{ inputs.setup-vars }}
       - name: Run tests
         env:
           MARKERS: ${{ inputs.pytest-markers }}

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ endif
 setup-tests:
 	echo "Installing nothing..."
 	echo "Installed!"
+ifdef SETUP_EXTRA
+	echo "Setting up extra stuff"
+endif
 
 .PHONY: setup-docs
 setup-docs: install-uv  ##- Set up a documentation-only environment

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ jobs:
       lowest-python-platform: '["jammy", "arm64"]'
       use-lxd: true # If we should install lxd on the runner.
       pytest-markers: smoketest and not steamtest # Extra pytest marks to set, for example to break up large test sets
+      setup-vars: NO_INSTALL_PLUGIN_DEPS=1 # Extra variables to pass when running setup
 ```
 
 # Other Configuration


### PR DESCRIPTION
This allows us to pass an environment variable to craft-parts to tell it not to install the plugin dependencies unless we're actually testing plugins.

Real use-case: https://github.com/canonical/craft-parts/pull/1275/files