### PR TITLE
fix(lint-python): make the linter setup more resilient

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -31,6 +31,15 @@ jobs:
           for job in ${{ steps.snap-install.outputs.jobs }}; do
             sudo snap watch $job
           done
-          make -j setup-lint
+
+          # Try setting up the linters, but if it breaks try again after an apt update.
+          # It's written this way because mostly we don't need apt-get update and it just
+          # makes the job take longer, but when we do need it it's because a package deb
+          # got removed that makes the linter setup fail. This gets fixed automatically
+          # when GitHub rebuilds the image.
+          if ! make -j setup-lint; then
+            sudo apt-get update
+            make -j setup-lint
+          fi
       - name: Run linters
         run: make -k lint


### PR DESCRIPTION
 Try setting up the linters, but if it breaks try again after an apt update.
It's written this way because mostly we don't need apt-get update and it just makes the job take longer, but when we do need it it's because a package deb got removed that makes the linter setup fail. This gets fixed automatically when GitHub rebuilds the image.

Example breakage: https://github.com/canonical/charmcraft/actions/runs/20105487204/job/57702635457?pr=2524

Example run with the fix: https://github.com/canonical/starflow/actions/runs/20109782715/job/57703659987?pr=104#step:5:38