### PR TITLE
feat(renovate): don't check docs directory

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,7 @@
   // NOTE: This file acts as the renovate configuration for all Starcraft repositories.
   extends: ["config:recommended", ":semanticCommitTypeAll(build)", ":enablePreCommit"],
   labels: ["PR: Dependencies"],
+  ignorePaths: ["docs/requirements.txt"],
   baseBranchPatterns: ["$default", "/^hotfix\\/.*/"],
   pip_requirements: {
     managerFilePatterns: ["/^tox.ini$/", "/(^|/)requirements([\\w-]*)\\.txt$/"],


### PR DESCRIPTION
Per @medubelko's suggestion after seeing https://github.com/canonical/starbase/pull/481, the starter pack should not have renovate PRs reported to us (and in this particular case, it is unhelpfully introducing a bug in the newer version anyways...)