### PR TITLE
feat: ignore test directories with renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
   // NOTE: This file acts as the renovate configuration for all Starcraft repositories.
   extends: ["config:recommended", ":semanticCommitTypeAll(build)", ":enablePreCommit"],
   labels: ["PR: Dependencies"],
-  ignorePaths: ["docs/requirements.txt"],
+  ignorePaths: ["docs/requirements.txt", "tests/**"],
   baseBranchPatterns: ["$default", "/^hotfix\\/.*/"],
   pip_requirements: {
     managerFilePatterns: ["/^tox.ini$/", "/(^|/)requirements([\\w-]*)\\.txt$/"],


### PR DESCRIPTION
What it says on the tin.

Tests aren't really production code that needs to be securely updated, and sometimes intentionally out-of-date packages are used to model specific behaviors.