### PR TITLE
ci: remove filter from lint workflow

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -1,10 +1,11 @@
 name: Lint Python
 on:
   workflow_call:
-    outputs:
+    inputs:
       source-files:
         description: "Whether the changes affect source files"
-        value: ${{ jobs.files.outputs.source-files }}
+        type: string
+        default: "true"
   # Because we have a uv.lock file, we can also use this workflow to lint ourselves.
   pull_request:
     branches:
@@ -16,25 +17,15 @@ on:
 jobs:
   files:
     runs-on: ubuntu-latest
-    outputs:
-      source-files: ${{ steps.filter.outputs.source-files }}
     steps:
-      - name: Begin snap installs of common linters
-        id: snap-install
-        run: |
-          echo -n "jobs=$(sudo snap install --no-wait codespell ruff shellcheck)" >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
-          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
-          filters: |
-            source-files:
-              - '!({docs/**,*.md,**/*.md})'
+      - name: Begin snap installs of common linters
+        id: snap-install
+        run: |
+          echo -n "jobs=$(sudo snap install --no-wait codespell ruff shellcheck)" >> $GITHUB_OUTPUT
       - name: Set up uv with caching
         id: setup-uv
         uses: astral-sh/setup-uv@v8.1.0
@@ -56,8 +47,8 @@ jobs:
             make -j setup-lint
           fi
       - name: Run all linters
-        if: steps.filter.outputs.source-files == 'true'
+        if: ${{ inputs.source-files == 'true' }}
         run: make -k lint
       - name: Run documentation linters
-        if: steps.filter.outputs.source-files == 'false'
+        if: ${{ inputs.source-files == 'false' }}
         run: make -k docs-lint


### PR DESCRIPTION
The calling workflow will provide the filter. Otherwise, default to source files being affected.

Part of a fix for CRAFT-5161.