### PR TITLE
ci: make steps conditional in 'test python' workflow

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -55,6 +55,9 @@ on:
           Anything to prefix the `make test-coverage` command with. Useful when running tests as another user.
         default: ""
 
+# We add the same conditional to every job's steps, because GitHub doesn't count a
+# required-but-skipped job as complete if a matrix spawned it. This is an ugly
+# workaround that could be resolved if we had isolated CI chains.
 jobs:
   fast:
     name: Fast tests
@@ -63,11 +66,12 @@ jobs:
       matrix:
         platform: ${{ fromJson(inputs.fast-test-platforms) }}
     runs-on: ${{ matrix.platform }}
-    if: ${{ inputs.source-files == 'true' }}
     steps:
       - name: Set up runner
         uses: canonical/starflow/setup-python-runner@main
+        if: ${{ inputs.source-files == 'true' }}
       - name: Set up tests
+        if: ${{ inputs.source-files == 'true' }}
         shell: bash
         run: |
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do
@@ -75,6 +79,7 @@ jobs:
             make -j setup-tests UV_PROJECT_ENVIRONMENT="${python_dirname}" UV_PYTHON="${python_version}" ${{ inputs.setup-vars }}
           done
       - name: Run tests
+        if: ${{ inputs.source-files == 'true' }}
         shell: bash
         env:
           MARKERS: ${{ inputs.pytest-markers }}
@@ -92,6 +97,7 @@ jobs:
           done
           exit $exit_code
       - name: Upload test coverage
+        if: ${{ inputs.source-files == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: coverage-fast-${{ join(matrix.platform, '-') }}
@@ -106,22 +112,25 @@ jobs:
         platform: ${{ fromJson(inputs.slow-test-platforms) }}
         python-version: ${{ fromJson(inputs.slow-test-python-versions) }}
     runs-on: ${{ matrix.platform }}
-    if: ${{ inputs.source-files == 'true' }}
     steps:
       - name: Set up runner
         uses: canonical/starflow/setup-python-runner@main
+        if: ${{ inputs.source-files == 'true' }}
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools
+        if: ${{ inputs.source-files == 'true' }}
         run: |
           make -j setup-tests ${{ inputs.setup-vars }}
       - name: Run tests
+        if: ${{ inputs.source-files == 'true' }}
         env:
           MARKERS: ${{ inputs.pytest-markers }}
         run: |
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="--no-header -v -rN -m 'slow ${MARKERS:+and ($MARKERS)}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7
+        if: ${{ inputs.source-files == 'true' }}
         with:
           name: coverage-slow-${{ join(matrix.platform, '-') }}-${{ matrix.python-version }}
           overwrite: true
@@ -140,18 +149,22 @@ jobs:
     steps:
       - name: Set up runner
         uses: canonical/starflow/setup-python-runner@main
+        if: ${{ inputs.source-files == 'true' }}
         with:
           python-version: ${{ inputs.lowest-python-version }}
       - name: Install tools
+        if: ${{ inputs.source-files == 'true' }}
         run: |
           make -j setup-tests ${{ inputs.setup-vars }}
       - name: Run tests
+        if: ${{ inputs.source-files == 'true' }}
         env:
           MARKERS: ${{ inputs.pytest-markers }}
         run: |
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="-m '${MARKERS}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7
+        if: ${{ inputs.source-files == 'true' }}
         with:
           name: coverage-lowest-py${{ inputs.lowest-python-version }}
           overwrite: true


### PR DESCRIPTION
The intent is to make the test jobs conditional for docs-only changes. The technical circumstances are:

1. In most of our repos, only two of the matrix-spawned test jobs are required checks. So while most of the test jobs can fail, we can't skip the workflow completely.
2. Required jobs can't be skipped by a conditional if they're spawned by a matrix. If we make the job conditional, the required check will never be satisfied, and CI will idle forever waiting for it to start. This is a bug or flaw with GitHub. So we need another way to bypass the job's behaviour, while still letting it start.

The simplest workaround is to give each step in the job a conditional `if`. In effect, they all initiate but then immediately end. The job then technically passes, and is considered satisfied as far as GitHub is concerned.

The downside is that at a glance, the job reports that it passed, as if it had been a real run. The only way to distinguish an ersatz job is to review its runtime (less than five seconds, usually) or its log.

This solution also means that every CI run will show two different statuses for skipped checks. Regular required jobs with job-level `if`s will have the skipped status. Matrix-spawned checks will have the passed status. Therefore, our workflows will be less legible, because any CI run will show both.

Tested successfully in Rockcraft against my fork: https://github.com/canonical/rockcraft/pull/1216