### PR TITLE
docs: configure for ubuntu.com proxy

### DIFF
--- a/docs/_static/js/overwrite-links.js
+++ b/docs/_static/js/overwrite-links.js
@@ -1,0 +1,38 @@
+// Replace oldDomain with newDomain
+const oldDomain = 'documentation.ubuntu.com/starflow';
+const newDomain = 'ubuntu.com/docs/starflow';
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ html_theme_options = {
 #########################
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
-html_baseurl = ogp_site_url
+html_baseurl = f"{ogp_site_url}/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 sitemap_url_scheme = '{link}'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ if (
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)
 
 # Documentation website URL
-ogp_site_url = "https://canonical-starflow.readthedocs-hosted.com/"
+ogp_site_url = "https://ubuntu.com/docs/starflow"
 
 # Preview name of the documentation website
 ogp_site_name = project
@@ -85,7 +85,7 @@ html_theme_options = {
 #########################
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = ogp_site_url
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 sitemap_url_scheme = '{link}'
@@ -99,6 +99,10 @@ sitemap_excludes = [
     'genindex/',
     'search/',
 ]
+
+# Since there's only one version for Starflow, the default sitemap URL will conflict
+# with RTD's sitemap. This changes the filename so they don't collide.
+sitemap_filename = "doc-sitemap.xml"
 
 
 ################################
@@ -188,6 +192,7 @@ html_css_files = [
 # Adds custom JavaScript files, located under 'html_static_path'
 html_js_files = [
     'js/bundle.js',
+    'js/overwrite-links.js',
 ]
 
 # Specifies a reST snippet to be appended to each .rst file


### PR DESCRIPTION
First attempt at the ubuntu.com proxy. We're doing Starflow in production to get a better sense of how much downtime is incurred.

It's possible to do this without committing `overwrite-links.js` directly, but since Starflow only has one version, it's simpler and more visible to track here.