### PR TITLE
feat(test-python): allow tests to get secrets

### DIFF
--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -7,8 +7,6 @@ jobs:
     uses: ./.github/workflows/lint-python.yaml
   test-python:
     uses: ./.github/workflows/test-python.yaml
-    needs: lint-python
-    if: ${{ needs.lint-python.outputs.source-files == 'true' }}
     secrets:
       secret-1: ${{ secrets.REPO_SECRET }}
     with:
@@ -17,8 +15,6 @@ jobs:
         REPO_SECRET=$SECRET_1
   test-python-custom:
     uses: ./.github/workflows/test-python.yaml
-    needs: lint-python
-    if: ${{ needs.lint-python.outputs.source-files == 'true' }}
     secrets:
       secret-1: ${{ secrets.REPO_SECRET }}
     with:
@@ -38,8 +34,6 @@ jobs:
         REPO_SECRET=$SECRET_1
   test-python-as-root:
     uses: ./.github/workflows/test-python.yaml
-    needs: lint-python
-    if: ${{ needs.lint-python.outputs.source-files == 'true' }}
     secrets:
       secret-1: ${{ secrets.REPO_SECRET }}
     with:

--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -9,10 +9,16 @@ jobs:
     uses: ./.github/workflows/test-python.yaml
     needs: lint-python
     if: ${{ needs.lint-python.outputs.source-files == 'true' }}
+    secrets: inherit
+    with:
+      extra-env-vars: |
+        REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
+        REPO_SECRET=${{ secrets.REPO_SECRET }}
   test-python-custom:
     uses: ./.github/workflows/test-python.yaml
     needs: lint-python
     if: ${{ needs.lint-python.outputs.source-files == 'true' }}
+    secrets: inherit
     with:
       # Test on many OS's to ensure that these workflows work everywhere.
       # Also ensure we can add a list of tags for self-hosted runners.
@@ -25,10 +31,14 @@ jobs:
       use-lxd: true
       pytest-markers: smoketest and not steamtest
       setup-vars: SETUP_EXTRA=1
+      extra-env-vars: |
+        REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
+        REPO_SECRET=${{ secrets.REPO_SECRET }}
   test-python-as-root:
     uses: ./.github/workflows/test-python.yaml
     needs: lint-python
     if: ${{ needs.lint-python.outputs.source-files == 'true' }}
+    secrets: inherit
     with:
       # Test on many OS's to ensure that these workflows work everywhere.
       # Also ensure we can add a list of tags for self-hosted runners.
@@ -39,3 +49,6 @@ jobs:
       lowest-python-version: "3.8"
       lowest-python-platform: "ubuntu-latest"
       test-command-prefix: sudo # Test that we can run with sudo.
+      extra-env-vars: |
+        REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
+        REPO_SECRET=${{ secrets.REPO_SECRET }}

--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -45,7 +45,7 @@ jobs:
       slow-test-python-versions: '["3.14"]'
       lowest-python-version: "3.8"
       lowest-python-platform: "ubuntu-latest"
-      test-command-prefix: sudo # Test that we can run with sudo.
+      test-command-prefix: sudo -E # Test that we can run with sudo.
       extra-env-vars: |
         REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
         REPO_SECRET=$SECRET_1

--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -9,16 +9,18 @@ jobs:
     uses: ./.github/workflows/test-python.yaml
     needs: lint-python
     if: ${{ needs.lint-python.outputs.source-files == 'true' }}
-    secrets: inherit
+    secrets:
+      secret-1: ${{ secrets.REPO_SECRET }}
     with:
       extra-env-vars: |
         REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
-        REPO_SECRET=${{ secrets.REPO_SECRET }}
+        REPO_SECRET=$SECRET_1
   test-python-custom:
     uses: ./.github/workflows/test-python.yaml
     needs: lint-python
     if: ${{ needs.lint-python.outputs.source-files == 'true' }}
-    secrets: inherit
+    secrets:
+      secret-1: ${{ secrets.REPO_SECRET }}
     with:
       # Test on many OS's to ensure that these workflows work everywhere.
       # Also ensure we can add a list of tags for self-hosted runners.
@@ -33,12 +35,13 @@ jobs:
       setup-vars: SETUP_EXTRA=1
       extra-env-vars: |
         REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
-        REPO_SECRET=${{ secrets.REPO_SECRET }}
+        REPO_SECRET=$SECRET_1
   test-python-as-root:
     uses: ./.github/workflows/test-python.yaml
     needs: lint-python
     if: ${{ needs.lint-python.outputs.source-files == 'true' }}
-    secrets: inherit
+    secrets:
+      secret-1: ${{ secrets.REPO_SECRET }}
     with:
       # Test on many OS's to ensure that these workflows work everywhere.
       # Also ensure we can add a list of tags for self-hosted runners.
@@ -51,4 +54,4 @@ jobs:
       test-command-prefix: sudo # Test that we can run with sudo.
       extra-env-vars: |
         REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
-        REPO_SECRET=${{ secrets.REPO_SECRET }}
+        REPO_SECRET=$SECRET_1

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -246,12 +246,20 @@ jobs:
           SECRET_10: ${{ secrets.secret-10 }}
         run: |
           while IFS= read -r line; do
-            if [[ -n "$line" ]]; then
-              # Replace $SECRET_1..$SECRET_10 with their actual values
-              expanded_line=$(echo "$line" | sed "s/\$SECRET_1\b/$SECRET_1/g;s/\$SECRET_2\b/$SECRET_2/g;s/\$SECRET_3\b/$SECRET_3/g;s/\$SECRET_4\b/$SECRET_4/g;s/\$SECRET_5\b/$SECRET_5/g;s/\$SECRET_6\b/$SECRET_6/g;s/\$SECRET_7\b/$SECRET_7/g;s/\$SECRET_8\b/$SECRET_8/g;s/\$SECRET_9\b/$SECRET_9/g;s/\$SECRET_10\b/$SECRET_10/g")
-              export "$expanded_line"
-            fi
-          done <<< "${EXTRA_VARS}"
+            [[ -z "$line" ]] && continue
+            # Replace literal $SECRET_1..$SECRET_10 placeholders (10..1 avoids $SECRET_10 matching $SECRET_1 prefix)
+            expanded_line=${line//\$SECRET_10/$SECRET_10}
+            expanded_line=${expanded_line//\$SECRET_9/$SECRET_9}
+            expanded_line=${expanded_line//\$SECRET_8/$SECRET_8}
+            expanded_line=${expanded_line//\$SECRET_7/$SECRET_7}
+            expanded_line=${expanded_line//\$SECRET_6/$SECRET_6}
+            expanded_line=${expanded_line//\$SECRET_5/$SECRET_5}
+            expanded_line=${expanded_line//\$SECRET_4/$SECRET_4}
+            expanded_line=${expanded_line//\$SECRET_3/$SECRET_3}
+            expanded_line=${expanded_line//\$SECRET_2/$SECRET_2}
+            expanded_line=${expanded_line//\$SECRET_1/$SECRET_1}
+            export "$expanded_line"
+          done <<< "$EXTRA_VARS"
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="-m '${MARKERS}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -208,6 +208,8 @@ jobs:
             expanded_line=${expanded_line//\$SECRET_1/$SECRET_1}
             export "$expanded_line"
           done <<< "$EXTRA_VARS"
+          # Unset raw secret slots so they don't leak into make or sudo -E
+          unset SECRET_1 SECRET_2 SECRET_3 SECRET_4 SECRET_5 SECRET_6 SECRET_7 SECRET_8 SECRET_9 SECRET_10
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="--no-header -v -rN -m 'slow ${MARKERS:+and ($MARKERS)}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7
@@ -269,6 +271,8 @@ jobs:
             expanded_line=${expanded_line//\$SECRET_1/$SECRET_1}
             export "$expanded_line"
           done <<< "$EXTRA_VARS"
+          # Unset raw secret slots so they don't leak into make or sudo -E
+          unset SECRET_1 SECRET_2 SECRET_3 SECRET_4 SECRET_5 SECRET_6 SECRET_7 SECRET_8 SECRET_9 SECRET_10
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="-m '${MARKERS}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -193,12 +193,20 @@ jobs:
           SECRET_10: ${{ secrets.secret-10 }}
         run: |
           while IFS= read -r line; do
-            if [[ -n "$line" ]]; then
-              # Replace $SECRET_1..$SECRET_10 with their actual values
-              expanded_line=$(echo "$line" | sed "s/\$SECRET_1\b/$SECRET_1/g;s/\$SECRET_2\b/$SECRET_2/g;s/\$SECRET_3\b/$SECRET_3/g;s/\$SECRET_4\b/$SECRET_4/g;s/\$SECRET_5\b/$SECRET_5/g;s/\$SECRET_6\b/$SECRET_6/g;s/\$SECRET_7\b/$SECRET_7/g;s/\$SECRET_8\b/$SECRET_8/g;s/\$SECRET_9\b/$SECRET_9/g;s/\$SECRET_10\b/$SECRET_10/g")
-              export "$expanded_line"
-            fi
-          done <<< "${EXTRA_VARS}"
+            [[ -z "$line" ]] && continue
+            # Replace literal $SECRET_1..$SECRET_10 placeholders (10..1 avoids $SECRET_10 matching $SECRET_1 prefix)
+            expanded_line=${line//\$SECRET_10/$SECRET_10}
+            expanded_line=${expanded_line//\$SECRET_9/$SECRET_9}
+            expanded_line=${expanded_line//\$SECRET_8/$SECRET_8}
+            expanded_line=${expanded_line//\$SECRET_7/$SECRET_7}
+            expanded_line=${expanded_line//\$SECRET_6/$SECRET_6}
+            expanded_line=${expanded_line//\$SECRET_5/$SECRET_5}
+            expanded_line=${expanded_line//\$SECRET_4/$SECRET_4}
+            expanded_line=${expanded_line//\$SECRET_3/$SECRET_3}
+            expanded_line=${expanded_line//\$SECRET_2/$SECRET_2}
+            expanded_line=${expanded_line//\$SECRET_1/$SECRET_1}
+            export "$expanded_line"
+          done <<< "$EXTRA_VARS"
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="--no-header -v -rN -m 'slow ${MARKERS:+and ($MARKERS)}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -136,7 +136,8 @@ jobs:
             expanded_line=${expanded_line//\$SECRET_1/$SECRET_1}
             export "$expanded_line"
           done <<< "$EXTRA_VARS"
-
+          # Unset raw secret slots so they don't leak into make or sudo -E
+          unset SECRET_1 SECRET_2 SECRET_3 SECRET_4 SECRET_5 SECRET_6 SECRET_7 SECRET_8 SECRET_9 SECRET_10
           exit_code=0
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do
             echo "::group::Python ${python_version}"

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -59,7 +59,27 @@ on:
         description: |
           Additional environment variables to set on the runner, as a newline-separated list of KEY=VALUE pairs.
         default: ""
-
+    secrets:
+      secret-1:
+        required: false
+      secret-2:
+        required: false
+      secret-3:
+        required: false
+      secret-4:
+        required: false
+      secret-5:
+        required: false
+      secret-6:
+        required: false
+      secret-7:
+        required: false
+      secret-8:
+        required: false
+      secret-9:
+        required: false
+      secret-10:
+        required: false
 
 # We add the same conditional to every job's steps, because GitHub doesn't count a
 # required-but-skipped job as complete if a matrix spawned it. This is an ugly
@@ -90,10 +110,22 @@ jobs:
         env:
           MARKERS: ${{ inputs.pytest-markers }}
           EXTRA_VARS: ${{ inputs.extra-env-vars }}
+          SECRET_1: ${{ secrets.secret-1 }}
+          SECRET_2: ${{ secrets.secret-2 }}
+          SECRET_3: ${{ secrets.secret-3 }}
+          SECRET_4: ${{ secrets.secret-4 }}
+          SECRET_5: ${{ secrets.secret-5 }}
+          SECRET_6: ${{ secrets.secret-6 }}
+          SECRET_7: ${{ secrets.secret-7 }}
+          SECRET_8: ${{ secrets.secret-8 }}
+          SECRET_9: ${{ secrets.secret-9 }}
+          SECRET_10: ${{ secrets.secret-10 }}
         run: |
           while IFS= read -r line; do
             if [[ -n "$line" ]]; then
-              export "$line"
+              # Replace $SECRET_1..$SECRET_10 with their actual values
+              expanded_line=$(echo "$line" | sed "s/\$SECRET_1\b/$SECRET_1/g;s/\$SECRET_2\b/$SECRET_2/g;s/\$SECRET_3\b/$SECRET_3/g;s/\$SECRET_4\b/$SECRET_4/g;s/\$SECRET_5\b/$SECRET_5/g;s/\$SECRET_6\b/$SECRET_6/g;s/\$SECRET_7\b/$SECRET_7/g;s/\$SECRET_8\b/$SECRET_8/g;s/\$SECRET_9\b/$SECRET_9/g;s/\$SECRET_10\b/$SECRET_10/g")
+              export "$expanded_line"
             fi
           done <<< "${EXTRA_VARS}"
 
@@ -141,10 +173,22 @@ jobs:
         env:
           MARKERS: ${{ inputs.pytest-markers }}
           EXTRA_VARS: ${{ inputs.extra-env-vars }}
+          SECRET_1: ${{ secrets.secret-1 }}
+          SECRET_2: ${{ secrets.secret-2 }}
+          SECRET_3: ${{ secrets.secret-3 }}
+          SECRET_4: ${{ secrets.secret-4 }}
+          SECRET_5: ${{ secrets.secret-5 }}
+          SECRET_6: ${{ secrets.secret-6 }}
+          SECRET_7: ${{ secrets.secret-7 }}
+          SECRET_8: ${{ secrets.secret-8 }}
+          SECRET_9: ${{ secrets.secret-9 }}
+          SECRET_10: ${{ secrets.secret-10 }}
         run: |
           while IFS= read -r line; do
             if [[ -n "$line" ]]; then
-              export "$line"
+              # Replace $SECRET_1..$SECRET_10 with their actual values
+              expanded_line=$(echo "$line" | sed "s/\$SECRET_1\b/$SECRET_1/g;s/\$SECRET_2\b/$SECRET_2/g;s/\$SECRET_3\b/$SECRET_3/g;s/\$SECRET_4\b/$SECRET_4/g;s/\$SECRET_5\b/$SECRET_5/g;s/\$SECRET_6\b/$SECRET_6/g;s/\$SECRET_7\b/$SECRET_7/g;s/\$SECRET_8\b/$SECRET_8/g;s/\$SECRET_9\b/$SECRET_9/g;s/\$SECRET_10\b/$SECRET_10/g")
+              export "$expanded_line"
             fi
           done <<< "${EXTRA_VARS}"
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="--no-header -v -rN -m 'slow ${MARKERS:+and ($MARKERS)}'"
@@ -182,10 +226,22 @@ jobs:
         env:
           MARKERS: ${{ inputs.pytest-markers }}
           EXTRA_VARS: ${{ inputs.extra-env-vars }}
+          SECRET_1: ${{ secrets.secret-1 }}
+          SECRET_2: ${{ secrets.secret-2 }}
+          SECRET_3: ${{ secrets.secret-3 }}
+          SECRET_4: ${{ secrets.secret-4 }}
+          SECRET_5: ${{ secrets.secret-5 }}
+          SECRET_6: ${{ secrets.secret-6 }}
+          SECRET_7: ${{ secrets.secret-7 }}
+          SECRET_8: ${{ secrets.secret-8 }}
+          SECRET_9: ${{ secrets.secret-9 }}
+          SECRET_10: ${{ secrets.secret-10 }}
         run: |
           while IFS= read -r line; do
             if [[ -n "$line" ]]; then
-              export "$line"
+              # Replace $SECRET_1..$SECRET_10 with their actual values
+              expanded_line=$(echo "$line" | sed "s/\$SECRET_1\b/$SECRET_1/g;s/\$SECRET_2\b/$SECRET_2/g;s/\$SECRET_3\b/$SECRET_3/g;s/\$SECRET_4\b/$SECRET_4/g;s/\$SECRET_5\b/$SECRET_5/g;s/\$SECRET_6\b/$SECRET_6/g;s/\$SECRET_7\b/$SECRET_7/g;s/\$SECRET_8\b/$SECRET_8/g;s/\$SECRET_9\b/$SECRET_9/g;s/\$SECRET_10\b/$SECRET_10/g")
+              export "$expanded_line"
             fi
           done <<< "${EXTRA_VARS}"
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="-m '${MARKERS}'"

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -122,12 +122,20 @@ jobs:
           SECRET_10: ${{ secrets.secret-10 }}
         run: |
           while IFS= read -r line; do
-            if [[ -n "$line" ]]; then
-              # Replace $SECRET_1..$SECRET_10 with their actual values
-              expanded_line=$(echo "$line" | sed "s/\$SECRET_1\b/$SECRET_1/g;s/\$SECRET_2\b/$SECRET_2/g;s/\$SECRET_3\b/$SECRET_3/g;s/\$SECRET_4\b/$SECRET_4/g;s/\$SECRET_5\b/$SECRET_5/g;s/\$SECRET_6\b/$SECRET_6/g;s/\$SECRET_7\b/$SECRET_7/g;s/\$SECRET_8\b/$SECRET_8/g;s/\$SECRET_9\b/$SECRET_9/g;s/\$SECRET_10\b/$SECRET_10/g")
-              export "$expanded_line"
-            fi
-          done <<< "${EXTRA_VARS}"
+            [[ -z "$line" ]] && continue
+            # Replace literal $SECRET_1..$SECRET_10 placeholders (10..1 avoids $SECRET_10 matching $SECRET_1 prefix)
+            expanded_line=${line//\$SECRET_10/$SECRET_10}
+            expanded_line=${expanded_line//\$SECRET_9/$SECRET_9}
+            expanded_line=${expanded_line//\$SECRET_8/$SECRET_8}
+            expanded_line=${expanded_line//\$SECRET_7/$SECRET_7}
+            expanded_line=${expanded_line//\$SECRET_6/$SECRET_6}
+            expanded_line=${expanded_line//\$SECRET_5/$SECRET_5}
+            expanded_line=${expanded_line//\$SECRET_4/$SECRET_4}
+            expanded_line=${expanded_line//\$SECRET_3/$SECRET_3}
+            expanded_line=${expanded_line//\$SECRET_2/$SECRET_2}
+            expanded_line=${expanded_line//\$SECRET_1/$SECRET_1}
+            export "$expanded_line"
+          done <<< "$EXTRA_VARS"
 
           exit_code=0
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -54,6 +54,12 @@ on:
         description: |
           Anything to prefix the `make test-coverage` command with. Useful when running tests as another user.
         default: ""
+      extra-env-vars:
+        type: string
+        description: |
+          Additional environment variables to set on the runner, as a newline-separated list of KEY=VALUE pairs.
+        default: ""
+
 
 # We add the same conditional to every job's steps, because GitHub doesn't count a
 # required-but-skipped job as complete if a matrix spawned it. This is an ugly
@@ -83,7 +89,14 @@ jobs:
         shell: bash
         env:
           MARKERS: ${{ inputs.pytest-markers }}
+          EXTRA_VARS: ${{ inputs.extra-env-vars }}
         run: |
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              export "$line"
+            fi
+          done <<< "${EXTRA_VARS}"
+
           exit_code=0
           for python_version in $(echo '${{ inputs.fast-test-python-versions }}' | jq -r .[] | tr '\n' ' '); do
             echo "::group::Python ${python_version}"
@@ -124,9 +137,16 @@ jobs:
           make -j setup-tests ${{ inputs.setup-vars }}
       - name: Run tests
         if: ${{ inputs.source-files == 'true' }}
+        shell: bash
         env:
           MARKERS: ${{ inputs.pytest-markers }}
+          EXTRA_VARS: ${{ inputs.extra-env-vars }}
         run: |
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              export "$line"
+            fi
+          done <<< "${EXTRA_VARS}"
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="--no-header -v -rN -m 'slow ${MARKERS:+and ($MARKERS)}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7
@@ -158,9 +178,16 @@ jobs:
           make -j setup-tests ${{ inputs.setup-vars }}
       - name: Run tests
         if: ${{ inputs.source-files == 'true' }}
+        shell: bash
         env:
           MARKERS: ${{ inputs.pytest-markers }}
+          EXTRA_VARS: ${{ inputs.extra-env-vars }}
         run: |
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              export "$line"
+            fi
+          done <<< "${EXTRA_VARS}"
           ${{ inputs.test-command-prefix }} make test-coverage PYTEST_ADDOPTS="-m '${MARKERS}'"
       - name: Upload test coverage
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ test-coverage:
 	$(info "Running tests with extra pytest options: ${PYTEST_ADDOPTS}")
 	$(info "Markers set: $(MARKERS)")
 	$(info "Using Python ${UV_PYTHON}")
+	@if [ -z "$${REPO_VARIABLE}" ]; then echo "::error::REPO_VARIABLE is not set or empty"; exit 1; fi
+	@if [ -z "$${REPO_SECRET}" ]; then echo "::error::REPO_SECRET is not set or empty"; exit 1; fi
+	@echo "All required environment variables are set."
 	@touch coverage.xml
 
 # Below are intermediate targets for setup. They are not included in help as they should

--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ In order to do so, it expects the following `make` targets:
 
 Additional environment variables (such as secrets) can be passed to the test runner using the
 `extra-env-vars` input. This input takes a newline-separated list of `KEY=VALUE` pairs which will be
-exported before the tests are run. This can be combined with `secrets: inherit` to pass secrets
-to the tests.
+exported before the tests are run.
 
-Because we use the snaps of [codespell](https://snapcraft.io/codespell),
-[ruff](https://snapcraft.io/ruff) and [shellcheck](https://snapcraft.io/shellcheck)
-frequently, this workflow installs those as well as uv.
+Due to GitHub Actions limitations, secrets cannot be passed directly into the `extra-env-vars`
+string. Instead, you can map your secrets to generic slots (`secret-1` through `secret-10`) in the
+`secrets` block of the call, and then reference them as `$SECRET_1` through `$SECRET_10` in
+`extra-env-vars`.
 
 An example workflow:
 
@@ -187,20 +187,12 @@ on:
 jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
-    secrets: inherit
+    secrets:
+      secret-1: ${{ secrets.MY_SECRET_KEY }}
     with:
-      fast-test-platforms: '["ubuntu-22.04", "windows-latest", "macos-latest"]'
-      fast-test-python-versions: '["3.14"]'
-      slow-test-platforms: '["ubuntu-latest"]'
-      slow-test-python-versions: '["3.14"]'
-      lowest-python-version: "3.8"
-      lowest-python-platform: '["jammy", "arm64"]'
-      use-lxd: true # If we should install lxd on the runner.
-      pytest-markers: smoketest and not steamtest # Extra pytest marks to set, for example to break up large test sets
-      setup-vars: NO_INSTALL_PLUGIN_DEPS=1 # Extra variables to pass when running setup
-      test-command-prefix: sudo # Runs the tests with sudo so we can run as root.
+      ...
       extra-env-vars: | # Extra environment variables to pass to the tests
-        MY_SECRET_KEY=${{ secrets.MY_SECRET_KEY }}
+        MY_SECRET_KEY=$SECRET_1
         MY_VAR=value
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ In order to do so, it expects the following `make` targets:
 - `test-coverage`: Runs tests with test coverage. Fast and slow tests will use the
   `PYTEST_ADDOPTS` environment variable to run with or without the `slow` mark.
 
+Additional environment variables (such as secrets) can be passed to the test runner using the
+`extra-env-vars` input. This input takes a newline-separated list of `KEY=VALUE` pairs which will be
+exported before the tests are run. This can be combined with `secrets: inherit` to pass secrets
+to the tests.
+
 Because we use the snaps of [codespell](https://snapcraft.io/codespell),
 [ruff](https://snapcraft.io/ruff) and [shellcheck](https://snapcraft.io/shellcheck)
 frequently, this workflow installs those as well as uv.
@@ -182,6 +187,7 @@ on:
 jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    secrets: inherit
     with:
       fast-test-platforms: '["ubuntu-22.04", "windows-latest", "macos-latest"]'
       fast-test-python-versions: '["3.14"]'
@@ -193,6 +199,9 @@ jobs:
       pytest-markers: smoketest and not steamtest # Extra pytest marks to set, for example to break up large test sets
       setup-vars: NO_INSTALL_PLUGIN_DEPS=1 # Extra variables to pass when running setup
       test-command-prefix: sudo # Runs the tests with sudo so we can run as root.
+      extra-env-vars: | # Extra environment variables to pass to the tests
+        MY_SECRET_KEY=${{ secrets.MY_SECRET_KEY }}
+        MY_VAR=value
 ```
 
 # Other


### PR DESCRIPTION
This enables passing secrets to tests, allowing us to do things such as provide [Charmhub credentials to craft-store](https://github.com/canonical/craft-store/pull/369).

This is tested in https://github.com/canonical/craft-store/actions/runs/26833318632/job/79121105580 (note that the ubuntu one login tests succeed)

CRAFT-4895