### PR TITLE
feat: skip test categories

### DIFF
--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -49,3 +49,15 @@ jobs:
       extra-env-vars: |
         REPO_VARIABLE=${{ vars.REPO_VARIABLE }}
         REPO_SECRET=$SECRET_1
+  test-python-noop-platforms: # Test that the Python tests are all skipped when platforms are empty
+    uses: ./.github/workflows/test-python.yaml
+    with:
+      fast-test-platforms: ""
+      slow-test-platforms: ""
+      lowest-python-platform: ""
+  test-python-noop-versions: # Test that the Python tests are all skipped when versions are empty
+    uses: ./.github/workflows/test-python.yaml
+    with:
+      fast-test-python-versions: ""
+      slow-test-python-versions: ""
+      lowest-python-version: ""

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -81,12 +81,14 @@ on:
       secret-10:
         required: false
 
-# We add the same conditional to every job's steps, because GitHub doesn't count a
-# required-but-skipped job as complete if a matrix spawned it. This is an ugly
-# workaround that could be resolved if we had isolated CI chains.
+# We use step-level conditionals for 'source-files' because GitHub doesn't count
+# a required-but-skipped job as complete if a matrix spawned it (transient skip).
+# However, we use job-level conditionals for platforms/versions to avoid
+# strategy evaluation errors when they are empty (configuration-based skip).
 jobs:
   fast:
     name: Fast tests
+    if: ${{ inputs.fast-test-platforms != '' && inputs.fast-test-python-versions != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -161,6 +163,7 @@ jobs:
             htmlcov/**
   slow:
     name: Slow tests
+    if: ${{ inputs.slow-test-platforms != '' && inputs.slow-test-python-versions != '' }}
     strategy:
       matrix:
         platform: ${{ fromJson(inputs.slow-test-platforms) }}
@@ -228,7 +231,7 @@ jobs:
     runs-on: ${{ startsWith(inputs.lowest-python-platform, '[') && fromJson(inputs.lowest-python-platform) || inputs.lowest-python-platform }}
     env:
       UV_RESOLUTION: lowest
-    if: ${{ inputs.lowest-python-version != '' && inputs.source-files == 'true' }}
+    if: ${{ inputs.lowest-python-platform != '' && inputs.lowest-python-version != '' && inputs.source-files == 'true' }}
     steps:
       - name: Set up runner
         uses: canonical/starflow/setup-python-runner@main

--- a/README.md
+++ b/README.md
@@ -177,7 +177,11 @@ string. Instead, you can map your secrets to generic slots (`secret-1` through `
 `secrets` block of the call, and then reference them as `$SECRET_1` through `$SECRET_10` in
 `extra-env-vars`.
 
-An example workflow:
+Each of these test suites (fast, slow, or lowest) can be selectively disabled by passing an empty string
+(`''`) to any of their platform or version inputs. This is useful for projects that only need a subset
+of the testing suite.
+
+An example workflow demonstrating secret mapping and selective skipping:
 
 ```yaml
 name: Test Python
@@ -190,7 +194,8 @@ jobs:
     secrets:
       secret-1: ${{ secrets.MY_SECRET_KEY }}
     with:
-      ...
+      # Disable slow tests by providing an empty platform list
+      slow-test-platforms: ""
       extra-env-vars: | # Extra environment variables to pass to the tests
         MY_SECRET_KEY=$SECRET_1
         MY_VAR=value


### PR DESCRIPTION
This allows us to skip categories of tests (fast, slow) by setting their platforms or python versions to empty strings.

Fixes the failure messages we get about runs like https://github.com/canonical/craft-application/actions/runs/26884266512