### PR TITLE
feat(renovate): don't scan against sphinx-stack deps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -110,6 +110,10 @@
       prPriority: -4,
       matchBaseBranches: ["main"],
     },
+    {
+      matchJsonata: ["managerData.depGroup = 'docs-sphinx-stack'"],
+      enabled: false,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Ignores sphinx-stack dependencies during Renovate runs. An explanation can be found here: https://github.com/canonical/starbase/issues/541#issuecomment-4650245130

Running renovate locally with `LOG_LEVEL=debug npx --yes renovate --dry-run=full --platform=local` shows this for vale, for example (note the "`skipReason`")

```json5
               {
                 "packageName": "vale",
                 "depName": "vale",
                 "datasource": "pypi",
                 "depType": "dependency-groups",
                 "currentValue": "~=3.13",
                 "managerData": {"depGroup": "docs-sphinx-stack"},
                 "lockedVersion": "3.13.0.0",
                 "updates": [],
                 "skipReason": "disabled"
               },
```