### PR TITLE
docs: how-to guide for setting up staging secrets

### DIFF
--- a/docs/how-to/github-secrets-setup.rst
+++ b/docs/how-to/github-secrets-setup.rst
@@ -1,0 +1,77 @@
+.. meta::
+    :description: How to configure staging GitHub Actions variables and secrets for the Starcraft team's Ubuntu One staging account.
+
+.. _how-to-github-secrets-setup:
+
+Set up GitHub secrets for staging
+=================================
+
+This guide explains how to configure the credentials for the Starcraft team's Ubuntu One staging account used by CI workflows.
+
+Prerequisites
+-------------
+
+Before starting, ensure you have:
+
+* Administrator access to the target GitHub repository.
+* Access to the corporate password manager.
+* Access to the **Starcraft Shared Accounts** collection.
+
+Step-by-step guide
+------------------
+
+Navigate to repository settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Go to your repository on GitHub.
+2. Click **Settings**.
+3. In the left sidebar, select **Secrets and variables** > **Actions**.
+
+Retrieve the Starcraft team's Ubuntu One staging account credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Open the **Ubuntu SSO Staging** login for the Starcraft team's Ubuntu One staging
+   account in the **Starcraft Shared Accounts** collection.
+2. Confirm the username is ``starcraft-team+staging-sso@groups.canonical.com``.
+3. Copy the login password when you are ready to paste it into GitHub.
+
+Create the required GitHub entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add one Actions variable and one Actions secret to match the workflow configuration.
+
+1. Under **Secrets and variables** > **Actions**, open the **Variables** tab.
+2. Create a variable named ``STAGING_SSO_USERNAME`` with value
+   ``starcraft-team+staging-sso@groups.canonical.com``.
+3. Open the **Secrets** tab.
+4. Create a secret named ``STAGING_SSO_PASSWORD`` with the password from the Starcraft
+   team's Ubuntu One staging account.
+
+Configure workflow access
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Ensure the workflow job can access both the Actions variable and Actions secret.
+2. If credentials fail to load during a workflow run, check:
+
+   * ``STAGING_SSO_USERNAME`` exists as a GitHub variable.
+   * ``STAGING_SSO_PASSWORD`` exists as a GitHub secret.
+   * The names match the workflow YAML exactly.
+
+Use these values in ``qa.yaml``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example shows how to pass the variable and secret into a reusable workflow and expose
+them as environment variables for tests:
+
+.. code-block:: yaml
+
+    jobs:
+      test:
+        uses: canonical/starflow/.github/workflows/test-python.yaml@main
+        with:
+          extra-env-vars: |
+            STAGING_SSO_USERNAME=$SECRET_1
+            STAGING_SSO_PASSWORD=$SECRET_2
+        secrets:
+          secret-1: ${{ vars.STAGING_SSO_USERNAME }}
+          secret-2: ${{ secrets.STAGING_SSO_PASSWORD }}

--- a/docs/how-to/github-secrets-setup.rst
+++ b/docs/how-to/github-secrets-setup.rst
@@ -3,8 +3,8 @@
 
 .. _how-to-github-secrets-setup:
 
-Set up GitHub secrets for staging
-=================================
+Set up GitHub Actions variables and secrets for staging
+=======================================================
 
 This guide explains how to configure the credentials for the Starcraft team's Ubuntu One staging account used by CI workflows.
 

--- a/docs/how-to/github-secrets-setup.rst
+++ b/docs/how-to/github-secrets-setup.rst
@@ -57,7 +57,7 @@ Configure workflow access
    * ``STAGING_SSO_PASSWORD`` exists as a GitHub secret.
    * The names match the workflow YAML exactly.
 
-Use these values in ``qa.yaml``
+Use these values in a workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example shows how to pass the variable and secret into a reusable workflow and expose

--- a/docs/how-to/github-secrets-setup.rst
+++ b/docs/how-to/github-secrets-setup.rst
@@ -22,7 +22,7 @@ Before starting, ensure you have:
 Retrieve the Starcraft team's Ubuntu One staging account credentials
 --------------------------------------------------------------------
 
-1. In the corporate password manager, locate the **Starcraft Shared Accounts** 
+1. In the corporate password manager, locate the **Starcraft Shared Accounts**
    collection. Open the **Ubuntu SSO Staging** login.
 2. Confirm the username is ``starcraft-team+staging-sso@groups.canonical.com``.
 3. Copy the login password when you are ready to paste it into GitHub.
@@ -42,11 +42,10 @@ Add one Actions variable and one Actions secret to match the workflow configurat
 Configure workflow access
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Ensure the workflow job can access both the Actions variable and Actions secret.
-2. If credentials fail to load during a workflow run, check:
+If credentials fail to load during a workflow run, check:
 
-   * ``STAGING_SSO_USERNAME`` exists as a GitHub variable.
-   * ``STAGING_SSO_PASSWORD`` exists as a GitHub secret.
+   * ``vars.STAGING_SSO_USERNAME`` exists.
+   * ``secrets.STAGING_SSO_PASSWORD`` exists.
    * The names match the workflow YAML exactly.
 
 Use these values in a workflow

--- a/docs/how-to/github-secrets-setup.rst
+++ b/docs/how-to/github-secrets-setup.rst
@@ -17,21 +17,13 @@ Before starting, ensure you have:
 * Access to the corporate password manager.
 * Access to the **Starcraft Shared Accounts** collection.
 
-Step-by-step guide
-------------------
 
-Navigate to repository settings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Go to your repository on GitHub.
-2. Click **Settings**.
-3. In the left sidebar, select **Secrets and variables** > **Actions**.
 
 Retrieve the Starcraft team's Ubuntu One staging account credentials
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------------
 
-1. Open the **Ubuntu SSO Staging** login for the Starcraft team's Ubuntu One staging
-   account in the **Starcraft Shared Accounts** collection.
+1. In the corporate password manager, locate the **Starcraft Shared Accounts** 
+   collection. Open the **Ubuntu SSO Staging** login.
 2. Confirm the username is ``starcraft-team+staging-sso@groups.canonical.com``.
 3. Copy the login password when you are ready to paste it into GitHub.
 
@@ -40,7 +32,7 @@ Create the required GitHub entries
 
 Add one Actions variable and one Actions secret to match the workflow configuration.
 
-1. Under **Secrets and variables** > **Actions**, open the **Variables** tab.
+1. In the repository's settings, under **Secrets and variables** > **Actions**, open the **Variables** tab.
 2. Create a variable named ``STAGING_SSO_USERNAME`` with value
    ``starcraft-team+staging-sso@groups.canonical.com``.
 3. Open the **Secrets** tab.

--- a/docs/how-to/github-secrets-setup.rst
+++ b/docs/how-to/github-secrets-setup.rst
@@ -68,10 +68,9 @@ them as environment variables for tests:
     jobs:
       test:
         uses: canonical/starflow/.github/workflows/test-python.yaml@main
+        secrets:
+          secret-1: ${{ secrets.STAGING_SSO_PASSWORD }}
         with:
           extra-env-vars: |
-            STAGING_SSO_USERNAME=$SECRET_1
-            STAGING_SSO_PASSWORD=$SECRET_2
-        secrets:
-          secret-1: ${{ vars.STAGING_SSO_USERNAME }}
-          secret-2: ${{ secrets.STAGING_SSO_PASSWORD }}
+            STAGING_SSO_USERNAME=${{ vars.STAGING_SSO_USERNAME }}
+            STAGING_SSO_PASSWORD=$SECRET_1

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -7,9 +7,11 @@ These pages walk you through the manual processes and workflows in the Starcraft
 
 - :ref:`how-to-starcraft-style-guide`
 - :ref:`how-to-add-a-page-meta-description`
+- :ref:`how-to-github-secrets-setup`
 
 .. toctree::
     :hidden:
 
     starcraft-style-guide
     add-a-page-meta-description
+    github-secrets-setup

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,7 @@ sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
 sphinx-related-links>=0.1.2
+sphinxext-rediraffe==0.3.0
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2
 sphinx-ubuntu-images>=0.1.0


### PR DESCRIPTION
This adds a how-to guide for setting up our team Ubuntu SSO Staging account in a repository, keeping the username as a variable and the password as a secret.