### PR TITLE
ci(scan): allow ignoring files/directories

### DIFF
--- a/.github/workflows/scan-golang.yaml
+++ b/.github/workflows/scan-golang.yaml
@@ -7,8 +7,8 @@ on:
         required: false
         type: string
         description: |
-          Packages to install with apt when building or scanning with trivy.
-          This can be useful if creating a virtual environment has extra build-deps.
+          Deprecated: no longer used. This input is accepted but ignored.
+          It will be removed in a future version.
       osv-extra-args:
         required: false
         type: string
@@ -19,35 +19,11 @@ on:
         required: false
         type: string
         default: "--severity HIGH,CRITICAL --ignore-unfixed"
-        description: Additional arguments to pass to trivy.
+        description: |
+          Deprecated: Trivy has been removed from this workflow. This input is accepted but
+          ignored. It will be removed in a future version.
 
 jobs:
-  scan-trivy:
-    name: Trivy
-    runs-on: [ubuntu-latest]
-    steps:
-      - name: Install tools
-        run: |
-          trivy_job=$(sudo snap install --no-wait trivy)
-
-          # Workaround for https://github.com/actions/runner-images/issues/10977
-          echo "set man-db/auto-update false" | sudo debconf-communicate
-          sudo dpkg-reconfigure --frontend noninteractive man-db
-
-          if [[ -n "${{ inputs.packages }}" ]]; then
-            sudo apt-get update
-            sudo apt-get --yes install ${{ inputs.packages }}
-          fi
-          sudo snap watch $trivy_job
-      - name: Download trivy database
-        run: |
-          timeout 30s bash -c 'while ! trivy filesystem --download-db-only; do sleep 0.1; done'
-      - name: Checkout source
-        uses: actions/checkout@v6
-      - name: Scan project
-        if: ${{ !cancelled() }}
-        run: |
-          trivy fs ${{ inputs.trivy-extra-args }} .
   scan-osv:
     name: OSV-scanner
     runs-on: [ubuntu-latest]

--- a/.github/workflows/scan-golang.yaml
+++ b/.github/workflows/scan-golang.yaml
@@ -29,7 +29,7 @@ on:
           Files to remove from the source checkout before the OSV source scan, relative to the
           repository root. Useful for excluding root-level lockfiles that belong to a different
           ecosystem or are already covered by another scan. Each filename on its own line.
-      osv-source-exclude-paths:
+      osv-exclude-paths:
         required: false
         type: string
         description: |
@@ -64,9 +64,9 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           exclude_args=""
-          if [[ -n "${{ inputs.osv-source-exclude-paths }}" ]]; then
+          if [[ -n "${{ inputs.osv-exclude-paths }}" ]]; then
             IFS=$'\n'
-            for path in $(echo "${{ inputs.osv-source-exclude-paths }}"); do
+            for path in $(echo "${{ inputs.osv-exclude-paths }}"); do
               exclude_args="${exclude_args} --experimental-exclude source/${path}"
             done
             unset IFS

--- a/.github/workflows/scan-golang.yaml
+++ b/.github/workflows/scan-golang.yaml
@@ -7,7 +7,7 @@ on:
         required: false
         type: string
         description: |
-          Deprecated: no longer used. This input is accepted but ignored.
+          Deprecated: build tooling has been removed. This input is accepted but ignored.
           It will be removed in a future version.
       osv-extra-args:
         required: false
@@ -18,29 +18,57 @@ on:
       trivy-extra-args:
         required: false
         type: string
-        default: "--severity HIGH,CRITICAL --ignore-unfixed"
+        default: ""
         description: |
-          Deprecated: Trivy has been removed from this workflow. This input is accepted but
-          ignored. It will be removed in a future version.
+          Deprecated: Trivy has been removed. This input is accepted but ignored.
+          It will be removed in a future version.
+      osv-exclude-files:
+        required: false
+        type: string
+        description: |
+          Files to remove from the source checkout before the OSV source scan, relative to the
+          repository root. Useful for excluding root-level lockfiles that belong to a different
+          ecosystem or are already covered by another scan. Each filename on its own line.
+      osv-source-exclude-paths:
+        required: false
+        type: string
+        description: |
+          Paths to exclude from the OSV source scan, passed as repeated --experimental-exclude
+          flags. Useful for ignoring example projects or fixtures in docs/ or tests/ that contain
+          their own lockfiles. Each path on its own line.
+
+          See https://google.github.io/osv-scanner/usage/scan-source#excluding-paths for more
+          information.
 
 jobs:
   scan-osv:
     name: OSV-scanner
     runs-on: [ubuntu-latest]
-    env:
-      UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
     steps:
       - name: Install tools
         run: |
-          osv_job=$(sudo snap install --no-wait osv-scanner)
-          if [[ -n "${{ inputs.packages }}" ]]; then
-            sudo apt-get update
-            sudo apt-get --yes install ${{ inputs.packages }}
-          fi
-          sudo snap watch $osv_job
+          sudo snap install osv-scanner
       - name: Checkout source
         uses: actions/checkout@v6
-      - name: Scan project
+        with:
+          path: source
+      - name: Remove files from source scan
         if: ${{ !cancelled() }}
         run: |
-          osv-scanner ${{ inputs.osv-extra-args }} .
+          IFS=$'\n'
+          for file in ${{ inputs.osv-exclude-files }}; do
+            [[ -n "${file}" ]] && rm -f "source/${file}"
+          done
+          unset IFS
+      - name: Scan source
+        if: ${{ !cancelled() }}
+        run: |
+          exclude_args=""
+          if [[ -n "${{ inputs.osv-source-exclude-paths }}" ]]; then
+            IFS=$'\n'
+            for path in $(echo "${{ inputs.osv-source-exclude-paths }}"); do
+              exclude_args="${exclude_args} --experimental-exclude source/${path}"
+            done
+            unset IFS
+          fi
+          osv-scanner scan --recursive ${{ inputs.osv-extra-args }} ${exclude_args} source

--- a/.github/workflows/scan-golang.yaml
+++ b/.github/workflows/scan-golang.yaml
@@ -62,13 +62,14 @@ jobs:
           unset IFS
       - name: Scan source
         if: ${{ !cancelled() }}
+        working-directory: source
         run: |
           exclude_args=""
           if [[ -n "${{ inputs.osv-exclude-paths }}" ]]; then
             IFS=$'\n'
             for path in $(echo "${{ inputs.osv-exclude-paths }}"); do
-              exclude_args="${exclude_args} --experimental-exclude source/${path}"
+              exclude_args="${exclude_args} --experimental-exclude ${path}"
             done
             unset IFS
           fi
-          osv-scanner scan --recursive --allow-no-lockfiles ${{ inputs.osv-extra-args }} ${exclude_args} source
+          osv-scanner scan --recursive --allow-no-lockfiles ${{ inputs.osv-extra-args }} ${exclude_args} .

--- a/.github/workflows/scan-golang.yaml
+++ b/.github/workflows/scan-golang.yaml
@@ -71,4 +71,4 @@ jobs:
             done
             unset IFS
           fi
-          osv-scanner scan --recursive ${{ inputs.osv-extra-args }} ${exclude_args} source
+          osv-scanner scan --recursive --allow-no-lockfiles ${{ inputs.osv-extra-args }} ${exclude_args} source

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -163,4 +163,4 @@ jobs:
             done
             unset IFS
           fi
-          osv-scanner scan --recursive ${{ inputs.osv-extra-args }} ${exclude_args} source
+          osv-scanner scan --recursive --allow-no-lockfiles ${{ inputs.osv-extra-args }} ${exclude_args} source

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Find any existing requirements files
         shell: bash
         run: |
-          find -type f -name 'requirements*.txt' ${{ inputs.requirements-find-args }} -exec cp '{}' "${{ runner.temp }}/python-artefacts/requirements" \;
+          find -type f -name 'requirements*.txt' ! -path '*/docs/*' ${{ inputs.requirements-find-args }} -exec cp '{}' "${{ runner.temp }}/python-artefacts/requirements" \;
       - name: Build wheel
         shell: bash
         run: |

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -7,7 +7,8 @@ on:
         required: false
         type: string
         description: |
-          Additional packages to install with apt when building the wheel.
+          Deprecated: wheel building has been removed. This input is accepted but ignored.
+          It will be removed in a future version.
       uv-export:
         type: boolean
         default: true
@@ -18,8 +19,8 @@ on:
         type: string
         default: ""
         description: |
-          Additional arguments to use for find when finding requirements files. Can
-          be used to find additional files or to exclude files.
+          Deprecated: requirements files are now discovered via the recursive source scan.
+          This input is accepted but ignored. It will be removed in a future version.
       uv-export-extra-args:
         required: false
         type: string
@@ -27,6 +28,37 @@ on:
         description: |
           List of additional arguments for uv export commands (for example to ignore certain extras).
           Use multiline string to provide several sets of arguments.
+      uv-export-no-groups:
+        required: false
+        type: string
+        description: |
+          Dependency groups to exclude from uv export (e.g. docs-sphinx-stack). Each group on its
+          own line. The group must exist in the project's dependency-groups table and must not be
+          transitively included by any other active group (via include-group).
+      osv-exclude-files:
+        required: false
+        type: string
+        description: |
+          Files to remove from the source checkout before the OSV source scan, relative to the
+          repository root. Useful for excluding root-level lockfiles that belong to a different
+          ecosystem or are already covered by a filtered export. Each filename on its own line.
+      osv-source-exclude-paths:
+        required: false
+        type: string
+        description: |
+          Paths to exclude from the OSV source scan, passed as repeated --experimental-exclude
+          flags. Useful for ignoring example projects or fixtures in docs/ or tests/ that contain
+          their own lockfiles. Each path on its own line.
+
+          See https://google.github.io/osv-scanner/usage/scan-source#excluding-paths for more
+          information.
+      uv-sync-extra-args:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Deprecated: Trivy has been removed. This input is accepted but ignored.
+          It will be removed in a future version.
       osv-extra-args:
         required: false
         type: string
@@ -44,43 +76,35 @@ on:
 jobs:
   build-artefacts:
     name: Build artefacts
-    runs-on: [ubuntu-24.04] # Needs Noble specifically
+    runs-on: [ubuntu-latest]
     env:
       UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
     steps:
       - name: Install tools
         shell: bash
         run: |
-          uv_job=$(sudo snap install --no-wait --classic astral-uv)
-
-          # Workaround for https://github.com/actions/runner-images/issues/10977
-          echo "set man-db/auto-update false" | sudo debconf-communicate
-          sudo dpkg-reconfigure --frontend noninteractive man-db
-
-          sudo apt-get update
-          sudo apt-get --yes install python3-venv python3-build ${{ inputs.packages }}
-          sudo snap watch $uv_job
+          sudo snap install --classic astral-uv
           mkdir -p ${{ runner.temp }}/python-artefacts/requirements
       - name: Checkout source
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Find any existing requirements files
-        shell: bash
-        run: |
-          find -type f -name 'requirements*.txt' ! -path '*/docs/*' ${{ inputs.requirements-find-args }} -exec cp '{}' "${{ runner.temp }}/python-artefacts/requirements" \;
-      - name: Build wheel
-        shell: bash
-        run: |
-          python -m build --wheel --outdir ${{ runner.temp }}/python-artefacts
       - name: Create requirements files from uv
         if: ${{ inputs.uv-export && hashFiles('uv.lock') != ''}}
         run: |
+          no_group_args=""
+          if [[ -n "${{ inputs.uv-export-no-groups }}" ]]; then
+            IFS=$'\n'
+            for group in $(echo "${{ inputs.uv-export-no-groups }}"); do
+              no_group_args="${no_group_args} --no-group ${group}"
+            done
+            unset IFS
+          fi
           IFS=$'\n'
           for extras in $(echo "${{ inputs.uv-export-extra-args }}"); do
             unset IFS
             filename=uv-requirements.$(echo $extras | tr ' ' '_').txt
-            uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt $extras --output-file=${{ runner.temp }}/python-artefacts/requirements/$filename
+            uv export --frozen --no-editable --no-emit-workspace --format=requirements-txt $extras ${no_group_args} --output-file=${{ runner.temp }}/python-artefacts/requirements/$filename
           done
       - name: Upload artefacts
         uses: actions/upload-artifact@v7
@@ -112,7 +136,31 @@ jobs:
           for reqs in $(ls -1 requirements/*); do
             osv-scanner ${{ inputs.osv-extra-args }} --lockfile requirements.txt:${reqs}
           done
+      - name: Remove files from source scan
+        if: ${{ !cancelled() }}
+        run: |
+          files_to_remove="${{ inputs.osv-exclude-files }}"
+          # Implicitly ignore uv.lock if we exported, as it would be redundant to scan both
+          # Additionally, if `uv-export-no-groups` is set, scanning the lockfile would raise
+          # OSVs for groups the user tried to ignore anyways
+          if [[ "${{ inputs.uv-export }}" == "true" ]]; then
+            files_to_remove="uv.lock
+          ${files_to_remove}"
+          fi
+          IFS=$'\n'
+          for file in ${files_to_remove}; do
+            [[ -n "${file}" ]] && rm -f "source/${file}"
+          done
+          unset IFS
       - name: Scan source
         if: ${{ !cancelled() }}
         run: |
-          osv-scanner ${{ inputs.osv-extra-args }} source
+          exclude_args=""
+          if [[ -n "${{ inputs.osv-source-exclude-paths }}" ]]; then
+            IFS=$'\n'
+            for path in $(echo "${{ inputs.osv-source-exclude-paths }}"); do
+              exclude_args="${exclude_args} --experimental-exclude source/${path}"
+            done
+            unset IFS
+          fi
+          osv-scanner scan --recursive ${{ inputs.osv-extra-args }} ${exclude_args} source

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -52,13 +52,6 @@ on:
 
           See https://google.github.io/osv-scanner/usage/scan-source#excluding-paths for more
           information.
-      uv-sync-extra-args:
-        required: false
-        type: string
-        default: ""
-        description: |
-          Deprecated: Trivy has been removed. This input is accepted but ignored.
-          It will be removed in a future version.
       osv-extra-args:
         required: false
         type: string

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -42,7 +42,7 @@ on:
           Files to remove from the source checkout before the OSV source scan, relative to the
           repository root. Useful for excluding root-level lockfiles that belong to a different
           ecosystem or are already covered by a filtered export. Each filename on its own line.
-      osv-source-exclude-paths:
+      osv-exclude-paths:
         required: false
         type: string
         description: |
@@ -156,9 +156,9 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           exclude_args=""
-          if [[ -n "${{ inputs.osv-source-exclude-paths }}" ]]; then
+          if [[ -n "${{ inputs.osv-exclude-paths }}" ]]; then
             IFS=$'\n'
-            for path in $(echo "${{ inputs.osv-source-exclude-paths }}"); do
+            for path in $(echo "${{ inputs.osv-exclude-paths }}"); do
               exclude_args="${exclude_args} --experimental-exclude source/${path}"
             done
             unset IFS

--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -154,13 +154,14 @@ jobs:
           unset IFS
       - name: Scan source
         if: ${{ !cancelled() }}
+        working-directory: source
         run: |
           exclude_args=""
           if [[ -n "${{ inputs.osv-exclude-paths }}" ]]; then
             IFS=$'\n'
             for path in $(echo "${{ inputs.osv-exclude-paths }}"); do
-              exclude_args="${exclude_args} --experimental-exclude source/${path}"
+              exclude_args="${exclude_args} --experimental-exclude ${path}"
             done
             unset IFS
           fi
-          osv-scanner scan --recursive --allow-no-lockfiles ${{ inputs.osv-extra-args }} ${exclude_args} source
+          osv-scanner scan --recursive --allow-no-lockfiles ${{ inputs.osv-extra-args }} ${exclude_args} .

--- a/.github/workflows/self-test-scan.yaml
+++ b/.github/workflows/self-test-scan.yaml
@@ -11,3 +11,16 @@ jobs:
     uses: ./.github/workflows/scan-golang.yaml
   python:
     uses: ./.github/workflows/scan-python.yaml
+    with:
+      # Include all groups so the exclusions below are actually exercised.
+      uv-export-extra-args: "--all-extras --all-groups"
+      # Exclude all docs dependency groups. evil-mode contains an intentionally
+      # vulnerable version to smoke test the exclusion, while the others are
+      # genuine exclusions for things we want to ignore.
+      uv-export-no-groups: |
+        docs
+        docs-starter-pack
+        evil-mode
+      # Exclude the docs/ directory from the recursive source scan to suppress
+      # findings from docs/requirements.dummy.txt, also intentionally vulnerable
+      osv-source-exclude-paths: "docs/"

--- a/.github/workflows/self-test-scan.yaml
+++ b/.github/workflows/self-test-scan.yaml
@@ -10,7 +10,7 @@ jobs:
   golang:
     uses: ./.github/workflows/scan-golang.yaml
     with:
-      osv-source-exclude-paths: "docs/"
+      osv-exclude-paths: "docs/"
       osv-exclude-files: "uv.lock"
   python:
     uses: ./.github/workflows/scan-python.yaml
@@ -26,4 +26,4 @@ jobs:
         evil-mode
       # Exclude the docs/ directory from the recursive source scan to suppress
       # findings from docs/requirements.dummy.txt, also intentionally vulnerable
-      osv-source-exclude-paths: "docs/"
+      osv-exclude-paths: "docs/"

--- a/.github/workflows/self-test-scan.yaml
+++ b/.github/workflows/self-test-scan.yaml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/scan-golang.yaml
     with:
       osv-source-exclude-paths: "docs/"
+      osv-exclude-files: "uv.lock"
   python:
     uses: ./.github/workflows/scan-python.yaml
     with:

--- a/.github/workflows/self-test-scan.yaml
+++ b/.github/workflows/self-test-scan.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   golang:
     uses: ./.github/workflows/scan-golang.yaml
+    with:
+      osv-source-exclude-paths: "docs/"
   python:
     uses: ./.github/workflows/scan-python.yaml
     with:

--- a/.test-data/uv.lock
+++ b/.test-data/uv.lock
@@ -1,7 +1,0 @@
-DO NOT DELETE
-
-This file exists to provide the `setup-uv` job with a uv.lock file in this repository.
-It doesn't get used for anything but the UV cache. To use a fresh cache, bump the number
-below:
-
-Cache reset count: 0

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ to scan a Python project for security issues. It does the following:
    can be customised with `uv-export-extra-args` (e.g. to include all extras or dependency
    groups), and specific dependency groups can be excluded with `uv-export-no-groups`.
 2. Scans the exported requirements file for known vulnerabilities.
-3. Recursively scans the project source tree for any other lockfiles. If `uv-export-no-groups`
-   is set, `uv.lock` is excluded from this scan since the filtered export replaces it.
+3. Recursively scans the project source tree for any other lockfiles. When `uv-export` is
+   enabled, `uv.lock` is excluded from this scan since the requirements export already covers
+   it.
 
 Exporting a `uv.lock` file can be disabled by setting `uv-export: false`.
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ The Python security scanner workflow uses [OSV-scanner](https://google.github.io
 to scan a Python project for security issues. It does the following:
 
 1. Runs `uv export` to extract a project's requirements from its `uv.lock` file. The workflow can
-  dictate the [export command's options](https://docs.astral.sh/uv/reference/cli/#uv-export) with
-  the `uv-export-extra-args` input. The workflow can also exclude a dependency group by listing it
-  in the `uv-export-no-groups` input.
+   dictate the [export command's options](https://docs.astral.sh/uv/reference/cli/#uv-export) with
+   the `uv-export-extra-args` input. The workflow can also exclude a dependency group by listing it
+   in the `uv-export-no-groups` input.
 2. Scans the exported requirements file for known vulnerabilities.
 3. Recursively scans the project source tree for any other lockfiles.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ to scan a Python project for security issues. It does the following:
    the `uv-export-extra-args` input. The workflow can also exclude a dependency group by listing it
    in the `uv-export-no-groups` input.
 2. Scans the exported requirements file for known vulnerabilities.
-3. Recursively scans the project source tree for any other lockfiles.
+3. Recursively searches the project source tree for any other lockfiles.
+4. Scans any found lockfiles for known vulnerabilities.
 
 Exporting a `uv.lock` file can be disabled by setting `uv-export: false`.
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,12 @@ jobs:
 The Python security scanner workflow uses [OSV-scanner](https://google.github.io/osv-scanner/)
 to scan a Python project for security issues. It does the following:
 
-1. Exports a `uv.lock` file (if present) as a requirements file using `uv export`. The export
-   can be customised with `uv-export-extra-args` (e.g. to include all extras or dependency
-   groups), and specific dependency groups can be excluded with `uv-export-no-groups`.
+1. Runs `uv export` to extract a project's requirements from its `uv.lock` file. The workflow can
+  dictate the [export command's options](https://docs.astral.sh/uv/reference/cli/#uv-export) with
+  the `uv-export-extra-args` input. The workflow can also exclude a dependency group by listing it
+  in the `uv-export-no-groups` input.
 2. Scans the exported requirements file for known vulnerabilities.
-3. Recursively scans the project source tree for any other lockfiles. When `uv-export` is
-   enabled, `uv.lock` is excluded from this scan since the requirements export already covers
-   it.
+3. Recursively scans the project source tree for any other lockfiles.
 
 Exporting a `uv.lock` file can be disabled by setting `uv-export: false`.
 
@@ -105,7 +104,7 @@ jobs:
       # Exclude docs/ from the recursive source scan (e.g. to ignore example lockfiles).
       osv-exclude-paths: "docs/"
       # Pass additional arguments to osv-scanner, e.g. a project config file.
-      osv-extra-args: "--config=source/osv-scanner.toml"
+      osv-extra-args: "--config=osv-scanner.toml"
 ```
 
 ## Go security scanner
@@ -135,7 +134,7 @@ jobs:
       # Exclude docs/ from the recursive source scan (e.g. to ignore example lockfiles).
       osv-exclude-paths: "docs/"
       # Pass additional arguments to osv-scanner, e.g. a project config file.
-      osv-extra-args: "--config=source/osv-scanner.toml"
+      osv-extra-args: "--config=osv-scanner.toml"
 ```
 
 ## Python test runner

--- a/README.md
+++ b/README.md
@@ -109,12 +109,13 @@ jobs:
 
 ## Go security scanner
 
-The Go security scanner workflow uses several tools (trivy, osv-scanner) to scan a
-Go project for security issues.
+The Go security scanner workflow uses [OSV-scanner](https://google.github.io/osv-scanner/)
+to scan a Go project for security issues. It recursively scans the project source tree for
+known vulnerabilities in any lockfiles it finds.
 
 ### Usage
 
-An example workflow for your own Go project that will use this workflow:
+An example workflow for a Go project that excludes the `docs/` directory from the scan:
 
 ```yaml
 name: Security scan
@@ -130,13 +131,10 @@ jobs:
     name: Scan Go project
     uses: canonical/starflow/.github/workflows/scan-golang.yaml@main
     with:
-      # Additional packages to install on the Ubuntu runners for building
-      packages: protoc-gen-go-1-3
-      # Additional arguments to pass to osv-scanner.
-      # This example adds configuration from your project.
-      osv-extra-args: "--config=.osv-scanner.toml"
-      # Use the standard extra args and ignore spread tests
-      trivy-extra-args: '--skip-dirs "tests/spread/**"'
+      # Exclude docs/ from the recursive source scan (e.g. to ignore example lockfiles).
+      osv-source-exclude-paths: "docs/"
+      # Pass additional arguments to osv-scanner, e.g. a project config file.
+      osv-extra-args: "--config=source/osv-scanner.toml"
 ```
 
 ## Python test runner

--- a/README.md
+++ b/README.md
@@ -67,22 +67,19 @@ jobs:
 The Python security scanner workflow uses [OSV-scanner](https://google.github.io/osv-scanner/)
 to scan a Python project for security issues. It does the following:
 
-1. Creates a wheel of the project.
-2. Exports a `uv.lock` file (if present in the project) as two requirements files:
-   a. `requirements.txt` with no extras
-   b. `requirements-all.txt` with all available extras
+1. Exports a `uv.lock` file (if present) as a requirements file using `uv export`. The export
+   can be customised with `uv-export-extra-args` (e.g. to include all extras or dependency
+   groups), and specific dependency groups can be excluded with `uv-export-no-groups`.
+2. Scans the exported requirements file for known vulnerabilities.
+3. Recursively scans the project source tree for any other lockfiles. If `uv-export-no-groups`
+   is set, `uv.lock` is excluded from this scan since the filtered export replaces it.
 
-If there are any existing `requirements*.txt` files in your project, it will scan those
-below too. Exporting a `uv.lock` file can be disabled by setting `uv-export: false`.
-
-With [OSV-scanner](https://google.github.io/osv-scanner/) it:
-
-1. Scans the requirements files
-2. Scans the project directory
+Exporting a `uv.lock` file can be disabled by setting `uv-export: false`.
 
 ### Usage
 
-An example workflow for your own Python project that will use this workflow:
+An example workflow for a Python project that excludes documentation dependencies from
+the scan and suppresses findings from the `docs/` directory:
 
 ```yaml
 name: Security scan
@@ -98,13 +95,15 @@ jobs:
     name: Scan Python project
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
-      # Additional packages to install on the Ubuntu runners for building
-      packages: python-apt-dev cargo
-      # Additional arguments to `find` when finding requirements files.
-      # This example ignores 'requirements-noble.txt'
-      requirements-find-args: "! -name requirements-noble.txt"
-      # Additional arguments to pass to osv-scanner.
-      # This example adds configuration from your project.
+      # Include all dependency groups in the export, then exclude the docs groups.
+      # The docs-sphinx-stack group must be defined in pyproject.toml.
+      uv-export-extra-args: "--all-extras --all-groups"
+      uv-export-no-groups: |
+        docs
+        docs-sphinx-stack
+      # Exclude docs/ from the recursive source scan (e.g. to ignore example lockfiles).
+      osv-source-exclude-paths: "docs/"
+      # Pass additional arguments to osv-scanner, e.g. a project config file.
       osv-extra-args: "--config=source/osv-scanner.toml"
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ jobs:
         docs
         docs-sphinx-stack
       # Exclude docs/ from the recursive source scan (e.g. to ignore example lockfiles).
-      osv-source-exclude-paths: "docs/"
+      osv-exclude-paths: "docs/"
       # Pass additional arguments to osv-scanner, e.g. a project config file.
       osv-extra-args: "--config=source/osv-scanner.toml"
 ```
@@ -132,7 +132,7 @@ jobs:
     uses: canonical/starflow/.github/workflows/scan-golang.yaml@main
     with:
       # Exclude docs/ from the recursive source scan (e.g. to ignore example lockfiles).
-      osv-source-exclude-paths: "docs/"
+      osv-exclude-paths: "docs/"
       # Pass additional arguments to osv-scanner, e.g. a project config file.
       osv-extra-args: "--config=source/osv-scanner.toml"
 ```

--- a/docs/requirements.dummy.txt
+++ b/docs/requirements.dummy.txt
@@ -1,0 +1,2 @@
+# Used for self-testing, this is an intentionally terrifying file for OSV Scanner & Trivy.
+urllib3==1

--- a/docs/requirements.dummy.txt
+++ b/docs/requirements.dummy.txt
@@ -1,2 +1,2 @@
-# Used for self-testing, this is an intentionally terrifying file for OSV Scanner & Trivy.
+# Used for self-testing, this is an intentionally terrifying file for OSV Scanner.
 urllib3==1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ docs = [
     "sphinxext-rediraffe==0.3.0",
     {include-group = "docs-starter-pack"},
 ]
+evil-mode = [
+    # Intentionally vulnerable package — used to self-test that uv-export-no-groups
+    # exclusion works in .github/workflows/self-test-scan.yaml.
+    "cryptography==3.3.2",
+]
+
 # We disable the unused but default SP dependencies slated for removal
 # https://warthogs.atlassian.net/browse/DOCPR-2387
 docs-starter-pack = [

--- a/uv.lock
+++ b/uv.lock
@@ -1187,9 +1187,6 @@ docs = [
     { name = "sphinxext-rediraffe" },
     { name = "vale" },
 ]
-docs-sphinx-stack = [
-    { name = "cryptography" },
-]
 docs-starter-pack = [
     { name = "canonical-sphinx" },
     { name = "myst-parser" },
@@ -1207,6 +1204,9 @@ docs-starter-pack = [
     { name = "sphinxcontrib-jquery" },
     { name = "sphinxext-opengraph" },
     { name = "vale" },
+]
+evil-mode = [
+    { name = "cryptography" },
 ]
 
 [package.metadata]
@@ -1234,7 +1234,6 @@ docs = [
     { name = "sphinxext-rediraffe", specifier = "==0.3.0" },
     { name = "vale", specifier = ">=3.13.0.0" },
 ]
-docs-sphinx-stack = [{ name = "cryptography", specifier = "==3.3.2" }]
 docs-starter-pack = [
     { name = "canonical-sphinx", specifier = "~=0.6" },
     { name = "myst-parser", specifier = ">=4.0.1" },
@@ -1251,6 +1250,7 @@ docs-starter-pack = [
     { name = "sphinxext-opengraph", specifier = ">=0.13.0" },
     { name = "vale", specifier = ">=3.13.0.0" },
 ]
+evil-mode = [{ name = "cryptography", specifier = "==3.3.2" }]
 
 [[package]]
 name = "starlette"

--- a/uv.lock
+++ b/uv.lock
@@ -88,6 +88,116 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/e9/6d7724983b3d5a0908dbf74f64038ade77c18646ff6636ec7894fd392ce1/cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0", size = 183837, upload-time = "2026-07-06T21:32:09.655Z" },
+    { url = "https://files.pythonhosted.org/packages/69/aa/24580a278de21fd7322635556334d9b535f1cbc00b0a3919447cdf464c65/cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd", size = 184226, upload-time = "2026-07-06T21:32:11.196Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a9/02cae418ec4beb282ace11958d9d4737793439d561fadc7e6d56f2e2b354/cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46", size = 211107, upload-time = "2026-07-06T21:32:12.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/30/c806937ed5e4c2c7ac30d9d6b76b5dc57ff8b75d83800d9bb11a8253cf2a/cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2", size = 218733, upload-time = "2026-07-06T21:32:13.67Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/cf/398272b8bbfd58aa314fda5a7f1cdbb26d1d78ae324a11211521315dd1f0/cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd", size = 205543, upload-time = "2026-07-06T21:32:15.148Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ca/f91641185cdd90c36d317a9dc7f85e88ef8682d8b300977baff5e23c35d8/cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3", size = 205460, upload-time = "2026-07-06T21:32:16.479Z" },
+    { url = "https://files.pythonhosted.org/packages/38/66/04781a77b411f0bb5b234d62c1814754ab75ebe455ccff1b08e8d7aae98f/cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0", size = 218760, upload-time = "2026-07-06T21:32:17.98Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9a/bb1d5ed9c3fcae158e9f6391bf309c95d98c2ac37ed56573228471d0af5e/cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43", size = 221230, upload-time = "2026-07-06T21:32:19.407Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/3c1409cdd26094efacd1c36c66e0a6eb9d4296e4fd4f9901b8b2042f4323/cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c", size = 213524, upload-time = "2026-07-06T21:32:20.828Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/75/74dfb7c3fc6ebbd408038476bd4c1d7e925c62614e7b9c534ecc34218288/cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd", size = 220341, upload-time = "2026-07-06T21:32:21.9Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b6/9003c33a3e7d2c1306f5962e646457dcfe5a8cd8fce6bbe02d7af25db783/cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f", size = 174578, upload-time = "2026-07-06T21:32:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/26/710688310447531c7a22f857c7f79d9855ec18b03e04494ced723fb37e2f/cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da", size = 185071, upload-time = "2026-07-06T21:32:24.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc", size = 183845, upload-time = "2026-07-06T21:32:26.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7", size = 184186, upload-time = "2026-07-06T21:32:28.025Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/9a5b7169499e8e8d8e636de70b97ac7c9447104d2ff1a2cd94790cea5162/cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c", size = 205737, upload-time = "2026-07-06T21:32:32.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b0/e131a9c41f10607926278453d9596163594fe1c4ebc46efe3b5e5b34eb84/cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f", size = 204909, upload-time = "2026-07-06T21:32:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/da/5c4918a2d61d86fa927d716cb3d8e4626ef8dc8f605a599d32f33897f59a/cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479", size = 174496, upload-time = "2026-07-06T21:32:40.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c8/6c2de1d55cf35ef8b92885d5ef280790f0fb9634d87ea1cc315176aecd61/cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458", size = 185113, upload-time = "2026-07-06T21:32:41.761Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/e8d7cb5783f1841a3c8fb3a7735838d7484d08ec08c9f984b14cac1ac0e9/cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d", size = 179927, upload-time = "2026-07-06T21:32:42.961Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -211,6 +321,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/85/38715448253404186029c575d559879912eb8a1c5d16ad9f25d35f7c4f4c/cryptography-3.3.2.tar.gz", hash = "sha256:5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed", size = 539883, upload-time = "2021-02-07T16:51:10.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/ea/6169c15d2f031fd8e950736fcba58a1e78e30f94dcd4e13de3acad9682d7/cryptography-3.3.2-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:0d7b69674b738068fa6ffade5c962ecd14969690585aaca0a1b1fc9058938a72", size = 1806119, upload-time = "2021-02-07T17:00:14.93Z" },
+    { url = "https://files.pythonhosted.org/packages/32/48/ec2a3e98d8b61d2c65e4c6905aad370049c4bd4a6b1b1d78f8983d38effe/cryptography-3.3.2-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:922f9602d67c15ade470c11d616f2b2364950602e370c76f0c94c94ae672742e", size = 2655339, upload-time = "2021-02-07T17:00:16.218Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d1/800ec785c9e66cc6d0ac587bd666eb22f7b2ff6c150e053d35881acd2f57/cryptography-3.3.2-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:a0f0b96c572fc9f25c3f4ddbf4688b9b38c69836713fb255f4a2715d93cbaf44", size = 2617074, upload-time = "2021-02-07T17:00:18.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e2/23313cd9d15c93c26d000c8917c3400ce1e4f0ae91a7bc7132578c2a69e3/cryptography-3.3.2-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:a777c096a49d80f9d2979695b835b0f9c9edab73b59e4ceb51f19724dda887ed", size = 2596498, upload-time = "2021-02-07T17:01:08.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d1/3167f1890afe03f8a6345351fb55cb7daa231f43ad2e0ca4b0d0bad85e23/cryptography-3.3.2-cp36-abi3-win32.whl", hash = "sha256:3c284fc1e504e88e51c428db9c9274f2da9f73fdf5d7e13a36b8ecb039af6e6c", size = 1274098, upload-time = "2021-02-07T17:00:19.659Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f1/6f03c4bdb33de207fe97fe771b0c671dfe30b55842f7d193205a1303d9e5/cryptography-3.3.2-cp36-abi3-win_amd64.whl", hash = "sha256:7951a966613c4211b6612b0352f5bf29989955ee592c4a885d8c7d0f830d0433", size = 1513103, upload-time = "2021-02-07T17:00:21.346Z" },
 ]
 
 [[package]]
@@ -464,6 +592,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -688,6 +825,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -1041,6 +1187,9 @@ docs = [
     { name = "sphinxext-rediraffe" },
     { name = "vale" },
 ]
+docs-sphinx-stack = [
+    { name = "cryptography" },
+]
 docs-starter-pack = [
     { name = "canonical-sphinx" },
     { name = "myst-parser" },
@@ -1085,6 +1234,7 @@ docs = [
     { name = "sphinxext-rediraffe", specifier = "==0.3.0" },
     { name = "vale", specifier = ">=3.13.0.0" },
 ]
+docs-sphinx-stack = [{ name = "cryptography", specifier = "==3.3.2" }]
 docs-starter-pack = [
     { name = "canonical-sphinx", specifier = "~=0.6" },
     { name = "myst-parser", specifier = ">=4.0.1" },


### PR DESCRIPTION
From the docs sync discussion, this change will make the OSV scanner ignore all docs issues moving forward.

The intended path for fixes now will be:
- All docs dependencies come from Sphinx Stack
- Sphinx Stack will patch these through its own OSV alerts
- Starbase will adopt new versions of Sphinx Stack
- Repositories will update Starbase, which gets them these patches.