### PR TITLE
fix(scan): fix path resolution for osv-scanner file arguments

### DIFF
--- a/.github/workflows/scan-python.yaml
+++ b/.github/workflows/scan-python.yaml
@@ -123,8 +123,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: artefacts
+          path: source
       - name: Scan requirements files
-        if: ${{ !cancelled() && hashFiles('requirements/') != '' }}
+        if: ${{ !cancelled() && hashFiles('source/requirements/') != '' }}
+        working-directory: source
         run: |
           for reqs in $(ls -1 requirements/*); do
             osv-scanner ${{ inputs.osv-extra-args }} --lockfile requirements.txt:${reqs}


### PR DESCRIPTION
Fixes an issue where something like `osv-extra-args: "--config-file=osv-scanner.toml"` would fail.

The original implementation of this action would leak an implementation detail that we copied the project into a directory named `source/`, and so any file names in `osv-extra-args` had to be prefixed, like `source/osv-scanner.toml`. I fixed one instance of this leaking in #157, but I missed this one.