### PR TITLE
fix(renovate): disable major/minor updates on hotfix branches

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,6 +37,12 @@
       matchPackageNames: ["/^craft-.*/"],
     },
     {
+      description: "Disable major and minor updates on hotfix branches",
+      matchBaseBranches: ["/^hotfix\\/.*/"],
+      matchUpdateTypes: ["major", "minor"],
+      enabled: false,
+    },
+    {
       groupName: "bugfixes",
       matchUpdateTypes: ["patch", "pin", "digest"],
       prPriority: 3,


### PR DESCRIPTION
## Summary
- add a Renovate package rule to disable major and minor dependency updates on hotfix branches
- keep patch/pin/digest updates available for hotfix branches

## Testing
- config-only change