### PR TITLE
fix(setup-python-runner): honour use-lxd input to skip LXD installation

### DIFF
--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -69,6 +69,52 @@ jobs:
       fast-test-python-versions: ""
       slow-test-python-versions: ""
       lowest-python-version: ""
+  test-python-no-lxd: # Regression test: use-lxd: false must actually skip setting up LXD
+    uses: ./.github/workflows/test-python.yaml
+    with:
+      fast-test-platforms: '["jammy"]'
+      fast-test-python-versions: '["3.14"]'
+      slow-test-platforms: ""
+      lowest-python-version: ""
+      use-lxd: false
+  verify-lxd-setup:
+    name: Verify use-lxd input is honored
+    if: ${{ !cancelled() }}
+    needs: [test-python-custom, test-python-no-lxd]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Setup LXD step outcomes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          jobs=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --paginate --jq '.jobs[] | {name, steps}')
+
+          # test-python-custom passes use-lxd: true, so at least one of its Linux
+          # runners must have successfully run the "Setup LXD" step.
+          lxd_true_success=$(echo "$jobs" | jq -s '[.[]
+            | select(.name | startswith("test-python-custom"))
+            | .steps[]? | select(.name == "Setup LXD" and .conclusion == "success")] | length')
+
+          # test-python-no-lxd passes use-lxd: false, so "Setup LXD" must never
+          # succeed (it should be skipped instead).
+          lxd_false_success=$(echo "$jobs" | jq -s '[.[]
+            | select(.name | startswith("test-python-no-lxd"))
+            | .steps[]? | select(.name == "Setup LXD" and .conclusion == "success")] | length')
+
+          echo "Setup LXD successes with use-lxd=true: ${lxd_true_success}"
+          echo "Setup LXD successes with use-lxd=false: ${lxd_false_success}"
+
+          exit_code=0
+          if [ "${lxd_true_success}" -lt 1 ]; then
+            echo "::error::Expected at least one successful 'Setup LXD' step when use-lxd is true"
+            exit_code=1
+          fi
+          if [ "${lxd_false_success}" -ne 0 ]; then
+            echo "::error::Expected no successful 'Setup LXD' steps when use-lxd is false"
+            exit_code=1
+          fi
+          exit $exit_code
   verify-coverage-artifacts:
     name: Verify coverage artifacts
     if: ${{ !cancelled() }}

--- a/.github/workflows/self-test-qa.yaml
+++ b/.github/workflows/self-test-qa.yaml
@@ -69,52 +69,6 @@ jobs:
       fast-test-python-versions: ""
       slow-test-python-versions: ""
       lowest-python-version: ""
-  test-python-no-lxd: # Regression test: use-lxd: false must actually skip setting up LXD
-    uses: ./.github/workflows/test-python.yaml
-    with:
-      fast-test-platforms: '["jammy"]'
-      fast-test-python-versions: '["3.14"]'
-      slow-test-platforms: ""
-      lowest-python-version: ""
-      use-lxd: false
-  verify-lxd-setup:
-    name: Verify use-lxd input is honored
-    if: ${{ !cancelled() }}
-    needs: [test-python-custom, test-python-no-lxd]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Setup LXD step outcomes
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          jobs=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
-            --paginate --jq '.jobs[] | {name, steps}')
-
-          # test-python-custom passes use-lxd: true, so at least one of its Linux
-          # runners must have successfully run the "Setup LXD" step.
-          lxd_true_success=$(echo "$jobs" | jq -s '[.[]
-            | select(.name | startswith("test-python-custom"))
-            | .steps[]? | select(.name == "Setup LXD" and .conclusion == "success")] | length')
-
-          # test-python-no-lxd passes use-lxd: false, so "Setup LXD" must never
-          # succeed (it should be skipped instead).
-          lxd_false_success=$(echo "$jobs" | jq -s '[.[]
-            | select(.name | startswith("test-python-no-lxd"))
-            | .steps[]? | select(.name == "Setup LXD" and .conclusion == "success")] | length')
-
-          echo "Setup LXD successes with use-lxd=true: ${lxd_true_success}"
-          echo "Setup LXD successes with use-lxd=false: ${lxd_false_success}"
-
-          exit_code=0
-          if [ "${lxd_true_success}" -lt 1 ]; then
-            echo "::error::Expected at least one successful 'Setup LXD' step when use-lxd is true"
-            exit_code=1
-          fi
-          if [ "${lxd_false_success}" -ne 0 ]; then
-            echo "::error::Expected no successful 'Setup LXD' steps when use-lxd is false"
-            exit_code=1
-          fi
-          exit $exit_code
   verify-coverage-artifacts:
     name: Verify coverage artifacts
     if: ${{ !cancelled() }}

--- a/.github/workflows/self-test-setup.yaml
+++ b/.github/workflows/self-test-setup.yaml
@@ -102,12 +102,15 @@ jobs:
           [[ $(lxc --version) =~ 5.0* ]]
   no-lxd:
     name: use-lxd disabled
+    permissions:
+      contents: read
     runs-on: ubuntu-26.04
     steps:
       - name: Fetch source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./setup-python-runner
         with:
           use-lxd: false

--- a/.github/workflows/self-test-setup.yaml
+++ b/.github/workflows/self-test-setup.yaml
@@ -100,3 +100,20 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           [[ $(lxc --version) =~ 5.0* ]]
+  no-lxd:
+    name: use-lxd disabled
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Fetch source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./setup-python-runner
+        with:
+          use-lxd: false
+      - name: Check lxd is not installed
+        run: |
+          if [ -e /snap/bin/lxc ]; then
+            echo "::error::/snap/bin/lxc should not exist when use-lxd is false"
+            exit 1
+          fi

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -98,6 +98,8 @@ jobs:
       - name: Set up runner
         uses: canonical/starflow/setup-python-runner@main
         if: ${{ inputs.source-files == 'true' }}
+        with:
+          use-lxd: ${{ inputs.use-lxd }}
       - name: Set up tests
         if: ${{ inputs.source-files == 'true' }}
         shell: bash
@@ -185,6 +187,7 @@ jobs:
         if: ${{ inputs.source-files == 'true' }}
         with:
           python-version: ${{ matrix.python-version }}
+          use-lxd: ${{ inputs.use-lxd }}
       - name: Install tools
         if: ${{ inputs.source-files == 'true' }}
         run: |
@@ -258,6 +261,7 @@ jobs:
         if: ${{ inputs.source-files == 'true' }}
         with:
           python-version: ${{ inputs.lowest-python-version }}
+          use-lxd: ${{ inputs.use-lxd }}
       - name: Install tools
         if: ${{ inputs.source-files == 'true' }}
         run: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -40,7 +40,7 @@ on:
         type: boolean
         description: |
           Whether to set up LXD on Linux runners.
-        default: false
+        default: true
       pytest-markers:
         type: string
         description: |

--- a/setup-python-runner/README.md
+++ b/setup-python-runner/README.md
@@ -22,6 +22,10 @@ jobs:
 
 ## Inputs
 
+### `use-lxd`
+
+Whether to set up LXD on Linux runners. Defaults to `true`.
+
 ### `lxd-channel`
 
 The snap channel from which to install LXD. Defaults to the current LTS channel.

--- a/setup-python-runner/action.yaml
+++ b/setup-python-runner/action.yaml
@@ -2,6 +2,11 @@ name: Setup Python runner
 description: Set up a GitHub runner for Starcraft Python workflows
 
 inputs:
+  use-lxd:
+    type: boolean
+    description: |
+      Whether to set up LXD on Linux runners.
+    default: false
   lxd-channel:
     type: string
     default: 5.21/candidate
@@ -20,7 +25,7 @@ runs:
         nohup sudo apt-get update > /dev/null &
         echo "apt-pid=$!" >> "${GITHUB_OUTPUT}"
     - name: Setup LXD
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && inputs.use-lxd == 'true' }}
       uses: canonical/setup-lxd@v1
       with:
         channel: ${{ inputs.lxd-channel }}

--- a/setup-python-runner/action.yaml
+++ b/setup-python-runner/action.yaml
@@ -25,7 +25,7 @@ runs:
         nohup sudo apt-get update > /dev/null &
         echo "apt-pid=$!" >> "${GITHUB_OUTPUT}"
     - name: Setup LXD
-      if: ${{ runner.os == 'Linux' && inputs.use-lxd == 'true' }}
+      if: ${{ runner.os == 'Linux' && fromJSON(inputs.use-lxd) }}
       uses: canonical/setup-lxd@v1
       with:
         channel: ${{ inputs.lxd-channel }}

--- a/setup-python-runner/action.yaml
+++ b/setup-python-runner/action.yaml
@@ -6,7 +6,7 @@ inputs:
     type: boolean
     description: |
       Whether to set up LXD on Linux runners.
-    default: false
+    default: true
   lxd-channel:
     type: string
     default: 5.21/candidate


### PR DESCRIPTION
`use-lxd: false` had no effect: `setup-python-runner` never declared a `use-lxd` input (its "Setup LXD" step only checked `runner.os == 'Linux'`), and `test-python.yaml` never passed its `use-lxd` input through to the action.

Adds the input to the action, gates the LXD setup step on it, wires it through from `test-python.yaml`, and defaults it to `true` everywhere to preserve current behaviour. Adds regression self-tests.